### PR TITLE
Add minimum viable spellabet library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,27 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "getrandom"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
 
 [[package]]
 name = "is_ci"
@@ -71,47 +54,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "spellabet"
 version = "0.1.0"
-dependencies = [
- "rand",
-]
 
 [[package]]
 name = "spellout"
@@ -119,12 +63,6 @@ version = "0.1.0"
 dependencies = [
  "spellabet",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -12,6 +12,3 @@ repository = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellab
 license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-rand = "0.8.5"

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -1,24 +1,114 @@
 #![deny(clippy::all)]
 #![warn(clippy::nursery, clippy::pedantic)]
 
-use rand::seq::SliceRandom;
+use std::collections::HashMap;
 
-#[must_use]
-pub const fn add(left: usize, right: usize) -> usize {
-    left + right
+pub enum SpellingAlphabet {
+    Nato,
 }
 
-pub fn shuffle_array(nums: &mut [i32]) {
-    let mut rng = rand::thread_rng();
-    nums.shuffle(&mut rng);
+pub struct PhoneticConverter {
+    alphabet: HashMap<char, &'static str>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+impl PhoneticConverter {
+    #[must_use]
+    pub fn new(alphabet_type: &SpellingAlphabet) -> Self {
+        let alphabet = match alphabet_type {
+            SpellingAlphabet::Nato => {
+                let mut map = HashMap::new();
+                map.insert('a', "Alpha");
+                map.insert('b', "Bravo");
+                map.insert('c', "Charlie");
+                map.insert('d', "Delta");
+                map.insert('e', "Echo");
+                map.insert('f', "Foxtrot");
+                map.insert('g', "Golf");
+                map.insert('h', "Hotel");
+                map.insert('i', "India");
+                map.insert('j', "Juliet");
+                map.insert('k', "Kilo");
+                map.insert('l', "Lima");
+                map.insert('m', "Mike");
+                map.insert('n', "November");
+                map.insert('o', "Oscar");
+                map.insert('p', "Papa");
+                map.insert('q', "Quebec");
+                map.insert('r', "Romeo");
+                map.insert('s', "Sierra");
+                map.insert('t', "Tango");
+                map.insert('u', "Uniform");
+                map.insert('v', "Victor");
+                map.insert('w', "Whiskey");
+                map.insert('x', "X-ray");
+                map.insert('y', "Yankee");
+                map.insert('z', "Zulu");
+                map.insert('0', "Zero");
+                map.insert('1', "One");
+                map.insert('2', "Two");
+                map.insert('3', "Three");
+                map.insert('4', "Four");
+                map.insert('5', "Five");
+                map.insert('6', "Six");
+                map.insert('7', "Seven");
+                map.insert('8', "Eight");
+                map.insert('9', "Nine");
+                map.insert(' ', "Space");
+                map.insert('!', "Exclamation");
+                map.insert('"', "DoubleQuote");
+                map.insert('#', "Hash");
+                map.insert('$', "Dollars");
+                map.insert('%', "Percent");
+                map.insert('&', "Ampersand");
+                map.insert('(', "LeftParens");
+                map.insert(')', "RightParens");
+                map.insert('*', "Asterisk");
+                map.insert('+', "Plus");
+                map.insert(',', "Comma");
+                map.insert('-', "Dash");
+                map.insert('.', "Period");
+                map.insert('/', "ForeSlash");
+                map.insert(':', "Colon");
+                map.insert(';', "SemiColon");
+                map.insert('<', "LessThan");
+                map.insert('=', "Equals");
+                map.insert('>', "GreaterThan");
+                map.insert('?', "Question");
+                map.insert('@', "At");
+                map.insert('[', "LeftBracket");
+                map.insert('\'', "SingleQuote");
+                map.insert('\\', "BackSlash");
+                map.insert(']', "RightBracket");
+                map.insert('^', "Caret");
+                map.insert('_', "Underscore");
+                map.insert('`', "Backtick");
+                map.insert('{', "LeftBrace");
+                map.insert('|', "Pipe");
+                map.insert('}', "RightBrace");
+                map.insert('~', "Tilde");
+                map
+            }
+        };
+        Self { alphabet }
+    }
 
-    #[test]
-    fn test_add() {
-        assert_eq!(add(10, 32), 42);
+    #[must_use]
+    pub fn convert(&self, text: &str) -> String {
+        let mut result = String::new();
+        for c in text.chars() {
+            if let Some(word) = self.alphabet.get(&c.to_ascii_lowercase()) {
+                if c.is_lowercase() {
+                    result.push_str(&word.to_lowercase());
+                } else if c.is_uppercase() {
+                    result.push_str(&word.to_uppercase());
+                } else {
+                    result.push_str(word);
+                }
+            } else {
+                result.push(c);
+            }
+            result.push(' ');
+        }
+        result.trim_end().to_owned()
     }
 }

--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -1,16 +1,14 @@
 #![deny(clippy::all)]
 #![warn(clippy::nursery, clippy::pedantic)]
 
-use spellabet::shuffle_array;
+use spellabet::{PhoneticConverter, SpellingAlphabet};
 
 #[test]
-fn test_shuffle_array() {
-    let mut nums = [1, 2, 3, 4, 5];
-    let original = nums;
-    shuffle_array(&mut nums);
-
-    assert_eq!(nums.len(), original.len());
-    for num in &original {
-        assert!(nums.contains(num));
-    }
+fn test_convert() {
+    let converter = PhoneticConverter::new(&SpellingAlphabet::Nato);
+    let input = "Example123";
+    assert_eq!(
+        converter.convert(input),
+        "ECHO x-ray alpha mike papa lima echo One Two Three"
+    );
 }

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -1,12 +1,3 @@
-use spellabet::{add, shuffle_array};
-
 fn main() {
-    let left = 10;
-    let right = 32;
-    println!("Hello, world! {left} plus {right} is {}!", add(left, right));
-
-    let mut nums = [1, 2, 3, 4, 5];
-    println!("Unshuffled: {nums:?}");
-    shuffle_array(&mut nums);
-    println!("Shuffled:   {nums:?}");
+    println!("Hello, world!");
 }


### PR DESCRIPTION
This will need a lot of changes, but it's a start and gets the example output correct.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
