### PR TITLE
Use once_cell for lazy initialization of the alphabet HashMaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 [[package]]
 name = "spellabet"
 version = "0.1.0"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "spellout"

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -12,3 +12,6 @@ repository = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellab
 license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+once_cell = "1.17.1"

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -3,91 +3,95 @@
 
 use std::collections::HashMap;
 
+use once_cell::sync::Lazy;
+
+pub static NATO_ALPHABET: Lazy<HashMap<char, &'static str>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+    map.insert('a', "Alpha");
+    map.insert('b', "Bravo");
+    map.insert('c', "Charlie");
+    map.insert('d', "Delta");
+    map.insert('e', "Echo");
+    map.insert('f', "Foxtrot");
+    map.insert('g', "Golf");
+    map.insert('h', "Hotel");
+    map.insert('i', "India");
+    map.insert('j', "Juliet");
+    map.insert('k', "Kilo");
+    map.insert('l', "Lima");
+    map.insert('m', "Mike");
+    map.insert('n', "November");
+    map.insert('o', "Oscar");
+    map.insert('p', "Papa");
+    map.insert('q', "Quebec");
+    map.insert('r', "Romeo");
+    map.insert('s', "Sierra");
+    map.insert('t', "Tango");
+    map.insert('u', "Uniform");
+    map.insert('v', "Victor");
+    map.insert('w', "Whiskey");
+    map.insert('x', "X-ray");
+    map.insert('y', "Yankee");
+    map.insert('z', "Zulu");
+    map.insert('0', "Zero");
+    map.insert('1', "One");
+    map.insert('2', "Two");
+    map.insert('3', "Three");
+    map.insert('4', "Four");
+    map.insert('5', "Five");
+    map.insert('6', "Six");
+    map.insert('7', "Seven");
+    map.insert('8', "Eight");
+    map.insert('9', "Nine");
+    map.insert(' ', "Space");
+    map.insert('!', "Exclamation");
+    map.insert('"', "DoubleQuote");
+    map.insert('#', "Hash");
+    map.insert('$', "Dollars");
+    map.insert('%', "Percent");
+    map.insert('&', "Ampersand");
+    map.insert('(', "LeftParens");
+    map.insert(')', "RightParens");
+    map.insert('*', "Asterisk");
+    map.insert('+', "Plus");
+    map.insert(',', "Comma");
+    map.insert('-', "Dash");
+    map.insert('.', "Period");
+    map.insert('/', "ForeSlash");
+    map.insert(':', "Colon");
+    map.insert(';', "SemiColon");
+    map.insert('<', "LessThan");
+    map.insert('=', "Equals");
+    map.insert('>', "GreaterThan");
+    map.insert('?', "Question");
+    map.insert('@', "At");
+    map.insert('[', "LeftBracket");
+    map.insert('\'', "SingleQuote");
+    map.insert('\\', "BackSlash");
+    map.insert(']', "RightBracket");
+    map.insert('^', "Caret");
+    map.insert('_', "Underscore");
+    map.insert('`', "Backtick");
+    map.insert('{', "LeftBrace");
+    map.insert('|', "Pipe");
+    map.insert('}', "RightBrace");
+    map.insert('~', "Tilde");
+    map
+});
+
 pub enum SpellingAlphabet {
     Nato,
 }
 
 pub struct PhoneticConverter {
-    alphabet: HashMap<char, &'static str>,
+    alphabet: &'static HashMap<char, &'static str>,
 }
 
 impl PhoneticConverter {
     #[must_use]
     pub fn new(alphabet_type: &SpellingAlphabet) -> Self {
         let alphabet = match alphabet_type {
-            SpellingAlphabet::Nato => {
-                let mut map = HashMap::new();
-                map.insert('a', "Alpha");
-                map.insert('b', "Bravo");
-                map.insert('c', "Charlie");
-                map.insert('d', "Delta");
-                map.insert('e', "Echo");
-                map.insert('f', "Foxtrot");
-                map.insert('g', "Golf");
-                map.insert('h', "Hotel");
-                map.insert('i', "India");
-                map.insert('j', "Juliet");
-                map.insert('k', "Kilo");
-                map.insert('l', "Lima");
-                map.insert('m', "Mike");
-                map.insert('n', "November");
-                map.insert('o', "Oscar");
-                map.insert('p', "Papa");
-                map.insert('q', "Quebec");
-                map.insert('r', "Romeo");
-                map.insert('s', "Sierra");
-                map.insert('t', "Tango");
-                map.insert('u', "Uniform");
-                map.insert('v', "Victor");
-                map.insert('w', "Whiskey");
-                map.insert('x', "X-ray");
-                map.insert('y', "Yankee");
-                map.insert('z', "Zulu");
-                map.insert('0', "Zero");
-                map.insert('1', "One");
-                map.insert('2', "Two");
-                map.insert('3', "Three");
-                map.insert('4', "Four");
-                map.insert('5', "Five");
-                map.insert('6', "Six");
-                map.insert('7', "Seven");
-                map.insert('8', "Eight");
-                map.insert('9', "Nine");
-                map.insert(' ', "Space");
-                map.insert('!', "Exclamation");
-                map.insert('"', "DoubleQuote");
-                map.insert('#', "Hash");
-                map.insert('$', "Dollars");
-                map.insert('%', "Percent");
-                map.insert('&', "Ampersand");
-                map.insert('(', "LeftParens");
-                map.insert(')', "RightParens");
-                map.insert('*', "Asterisk");
-                map.insert('+', "Plus");
-                map.insert(',', "Comma");
-                map.insert('-', "Dash");
-                map.insert('.', "Period");
-                map.insert('/', "ForeSlash");
-                map.insert(':', "Colon");
-                map.insert(';', "SemiColon");
-                map.insert('<', "LessThan");
-                map.insert('=', "Equals");
-                map.insert('>', "GreaterThan");
-                map.insert('?', "Question");
-                map.insert('@', "At");
-                map.insert('[', "LeftBracket");
-                map.insert('\'', "SingleQuote");
-                map.insert('\\', "BackSlash");
-                map.insert(']', "RightBracket");
-                map.insert('^', "Caret");
-                map.insert('_', "Underscore");
-                map.insert('`', "Backtick");
-                map.insert('{', "LeftBrace");
-                map.insert('|', "Pipe");
-                map.insert('}', "RightBrace");
-                map.insert('~', "Tilde");
-                map
-            }
+            SpellingAlphabet::Nato => &*NATO_ALPHABET,
         };
         Self { alphabet }
     }


### PR DESCRIPTION
See:
- https://docs.rs/once_cell/latest/once_cell/
- https://github.com/rust-lang/rfcs/blob/master/text/2788-standard-lazy-types.md

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
