### PR TITLE
Add LAPD and US Financial spelling alphabets

### DIFF
--- a/crates/spellabet/src/code_words.rs
+++ b/crates/spellabet/src/code_words.rs
@@ -44,7 +44,8 @@ pub const DEFAULT_DIGITS_AND_SYMBOLS: [(char, &str); 43] = [
     ('~', "Tilde"),
 ];
 
-pub const LAPD_ALPHABET: [(char, &str); 26] = [
+// Los Angeles Police Department (LAPD)
+pub const LAPD_ALPHABET: [(char, &str); 27] = [
     ('a', "Adam"),
     ('b', "Boy"),
     ('c', "Charles"),
@@ -71,10 +72,12 @@ pub const LAPD_ALPHABET: [(char, &str); 26] = [
     ('x', "X-ray"),
     ('y', "Young"),
     ('z', "Zebra"),
+    ('9', "Niner"),
 ];
 
-pub const NATO_ALPHABET: [(char, &str); 26] = [
-    ('a', "Alpha"),
+// North Atlantic Treaty Organization (NATO)
+pub const NATO_ALPHABET: [(char, &str); 30] = [
+    ('a', "Alfa"),
     ('b', "Bravo"),
     ('c', "Charlie"),
     ('d', "Delta"),
@@ -83,7 +86,7 @@ pub const NATO_ALPHABET: [(char, &str); 26] = [
     ('g', "Golf"),
     ('h', "Hotel"),
     ('i', "India"),
-    ('j', "Juliet"),
+    ('j', "Juliett"),
     ('k', "Kilo"),
     ('l', "Lima"),
     ('m', "Mike"),
@@ -100,4 +103,8 @@ pub const NATO_ALPHABET: [(char, &str); 26] = [
     ('x', "X-ray"),
     ('y', "Yankee"),
     ('z', "Zulu"),
+    ('3', "Tree"),
+    ('4', "Fower"),
+    ('5', "Fife"),
+    ('9', "Niner"),
 ];

--- a/crates/spellabet/src/code_words.rs
+++ b/crates/spellabet/src/code_words.rs
@@ -44,6 +44,35 @@ pub const DEFAULT_DIGITS_AND_SYMBOLS: [(char, &str); 43] = [
     ('~', "Tilde"),
 ];
 
+pub const LAPD_ALPHABET: [(char, &str); 26] = [
+    ('a', "Adam"),
+    ('b', "Boy"),
+    ('c', "Charles"),
+    ('d', "David"),
+    ('e', "Edward"),
+    ('f', "Frank"),
+    ('g', "George"),
+    ('h', "Henry"),
+    ('i', "Ida"),
+    ('j', "John"),
+    ('k', "King"),
+    ('l', "Lincoln"),
+    ('m', "Mary"),
+    ('n', "Nora"),
+    ('o', "Ocean"),
+    ('p', "Paul"),
+    ('q', "Queen"),
+    ('r', "Robert"),
+    ('s', "Sam"),
+    ('t', "Tom"),
+    ('u', "Union"),
+    ('v', "Victor"),
+    ('w', "William"),
+    ('x', "X-ray"),
+    ('y', "Young"),
+    ('z', "Zebra"),
+];
+
 pub const NATO_ALPHABET: [(char, &str); 26] = [
     ('a', "Alpha"),
     ('b', "Bravo"),

--- a/crates/spellabet/src/code_words.rs
+++ b/crates/spellabet/src/code_words.rs
@@ -45,6 +45,7 @@ pub const DEFAULT_DIGITS_AND_SYMBOLS: [(char, &str); 43] = [
 ];
 
 // Los Angeles Police Department (LAPD)
+// Association of Public-Safety Communications Officials-International (APCO)
 pub const LAPD_ALPHABET: [(char, &str); 27] = [
     ('a', "Adam"),
     ('b', "Boy"),
@@ -76,6 +77,8 @@ pub const LAPD_ALPHABET: [(char, &str); 27] = [
 ];
 
 // North Atlantic Treaty Organization (NATO)
+// International Civil Aviation Organization (ICAO)
+// International Radiotelephony Spelling Alphabet (IRSA)
 pub const NATO_ALPHABET: [(char, &str); 30] = [
     ('a', "Alfa"),
     ('b', "Bravo"),
@@ -107,4 +110,34 @@ pub const NATO_ALPHABET: [(char, &str); 30] = [
     ('4', "Fower"),
     ('5', "Fife"),
     ('9', "Niner"),
+];
+
+// United States Financial Industry
+pub const US_FINANCIAL_ALPHABET: [(char, &str); 26] = [
+    ('a', "Adam"),
+    ('b', "Bob"),
+    ('c', "Carol"),
+    ('d', "David"),
+    ('e', "Eddie"),
+    ('f', "Frank"),
+    ('g', "George"),
+    ('h', "Harry"),
+    ('i', "Ike"),
+    ('j', "Jim"),
+    ('k', "Kenny"),
+    ('l', "Larry"),
+    ('m', "Mary"),
+    ('n', "Nancy"),
+    ('o', "Oliver"),
+    ('p', "Peter"),
+    ('q', "Quincy"),
+    ('r', "Roger"),
+    ('s', "Sam"),
+    ('t', "Thomas"),
+    ('u', "Uncle"),
+    ('v', "Vincent"),
+    ('w', "William"),
+    ('x', "Xavier"),
+    ('y', "Yogi"),
+    ('z', "Zachary"),
 ];

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use code_words::{DEFAULT_DIGITS_AND_SYMBOLS, LAPD_ALPHABET, NATO_ALPHABET};
+use code_words::{DEFAULT_DIGITS_AND_SYMBOLS, LAPD_ALPHABET, NATO_ALPHABET, US_FINANCIAL_ALPHABET};
 
 mod code_words;
 
@@ -14,6 +14,7 @@ pub struct PhoneticConverter {
 pub enum SpellingAlphabet {
     Lapd,
     Nato,
+    UsFinancial,
 }
 
 impl PhoneticConverter {
@@ -53,6 +54,7 @@ impl SpellingAlphabet {
         match self {
             Self::Lapd => extend_map(&mut map, &LAPD_ALPHABET),
             Self::Nato => extend_map(&mut map, &NATO_ALPHABET),
+            Self::UsFinancial => extend_map(&mut map, &US_FINANCIAL_ALPHABET),
         };
 
         map

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use code_words::{DEFAULT_DIGITS_AND_SYMBOLS, NATO_ALPHABET};
+use code_words::{DEFAULT_DIGITS_AND_SYMBOLS, LAPD_ALPHABET, NATO_ALPHABET};
 
 mod code_words;
 
@@ -12,6 +12,7 @@ pub struct PhoneticConverter {
 }
 
 pub enum SpellingAlphabet {
+    Lapd,
     Nato,
 }
 
@@ -46,13 +47,23 @@ impl PhoneticConverter {
 impl SpellingAlphabet {
     #[must_use]
     pub fn initialize(&self) -> HashMap<char, String> {
-        let mut map = DEFAULT_DIGITS_AND_SYMBOLS
-            .iter()
-            .map(|(k, v)| (*k, (*v).to_string()))
-            .collect::<HashMap<char, String>>();
+        let mut map: HashMap<char, String> = HashMap::new();
+        extend_map(&mut map, &DEFAULT_DIGITS_AND_SYMBOLS);
+
         match self {
-            Self::Nato => map.extend(NATO_ALPHABET.iter().map(|(k, v)| (*k, (*v).to_string()))),
+            Self::Lapd => extend_map(&mut map, &LAPD_ALPHABET),
+            Self::Nato => extend_map(&mut map, &NATO_ALPHABET),
         };
+
         map
     }
+}
+
+fn extend_map(map: &mut HashMap<char, String>, source_map: &[(char, &str)]) {
+    map.extend(
+        source_map
+            .iter()
+            .map(|(k, v)| (*k, (*v).to_string()))
+            .collect::<HashMap<char, String>>(),
+    );
 }

--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -9,6 +9,6 @@ fn test_convert() {
     let input = "Example123";
     assert_eq!(
         converter.convert(input),
-        "ECHO x-ray alpha mike papa lima echo One Two Three"
+        "ECHO x-ray alfa mike papa lima echo One Two Tree"
     );
 }


### PR DESCRIPTION
Note that some of the code words are spelled in an intentional way to avoid mispronunciation among international users.

See:
- https://en.wikipedia.org/wiki/NATO_phonetic_alphabet
- https://en.wikipedia.org/wiki/APCO_radiotelephony_spelling_alphabet
- https://www.thephoneticalphabet.com/financial-phonetic-alphabet.html

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
