### PR TITLE
Bump taiki-e/install-action from 2.8.8 to 2.9.0

### DIFF
--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -79,7 +79,7 @@ _#installRust: _#step & {
 // https://github.com/taiki-e/install-action/releases
 _#installTool: _#step & {
 	name: "Install \(with.tool)"
-	uses: "taiki-e/install-action@289298bb2d2c236894114a4c473c9c80813782a2"
+	uses: "taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3"
 	with: tool: string
 }
 

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -85,7 +85,7 @@ jobs:
           shared-key: stable-${{ matrix.platform }}
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@289298bb2d2c236894114a4c473c9c80813782a2
+        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
         with:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors
@@ -120,7 +120,7 @@ jobs:
           shared-key: msrv-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@289298bb2d2c236894114a4c473c9c80813782a2
+        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
         with:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
           shared-key: stable-${{ matrix.platform }}
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@289298bb2d2c236894114a4c473c9c80813782a2
+        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
         with:
           tool: cargo-nextest
       - name: Compile tests
@@ -154,7 +154,7 @@ jobs:
           shared-key: msrv-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@289298bb2d2c236894114a4c473c9c80813782a2
+        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
         with:
           tool: cargo-nextest
       - name: Compile tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set override to beta Rust
         run: rustup override set beta
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@289298bb2d2c236894114a4c473c9c80813782a2
+        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
         with:
           tool: cargo-nextest
       - name: Compile tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,6 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 [[package]]
 name = "spellabet"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "spellout"

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -12,6 +12,3 @@ repository = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellab
 license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-once_cell = "1.17.1"


### PR DESCRIPTION
Related to https://github.com/EarthmanMuons/spellout/pull/12

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
