### PR TITLE
Add nonce form output configuration option

### DIFF
--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -27,8 +27,20 @@ impl PhoneticConverter {
     #[must_use]
     pub fn convert(&self, text: &str) -> String {
         let mut result = String::new();
-        for c in text.chars() {
-            if let Some(word) = self.conversion_map.get(&c.to_ascii_lowercase()) {
+
+        for (i, c) in text.chars().enumerate() {
+            if i != 0 {
+                result.push(' ');
+            }
+            self.convert_char(c, &mut result);
+        }
+
+        result
+    }
+
+    fn convert_char(&self, c: char, result: &mut String) {
+        match self.conversion_map.get(&c.to_ascii_lowercase()) {
+            Some(word) => {
                 if c.is_lowercase() {
                     result.push_str(&word.to_lowercase());
                 } else if c.is_uppercase() {
@@ -36,12 +48,9 @@ impl PhoneticConverter {
                 } else {
                     result.push_str(word);
                 }
-            } else {
-                result.push(c);
             }
-            result.push(' ');
+            None => result.push(c),
         }
-        result.trim_end().to_owned()
     }
 }
 

--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -5,10 +5,25 @@ use spellabet::{PhoneticConverter, SpellingAlphabet};
 
 #[test]
 fn test_convert() {
-    let converter = PhoneticConverter::new(&SpellingAlphabet::Nato);
+    let alphabet = &SpellingAlphabet::Nato;
+    let converter = PhoneticConverter::new(alphabet);
     let input = "Example123";
+
     assert_eq!(
         converter.convert(input),
         "ECHO x-ray alfa mike papa lima echo One Two Tree"
+    );
+}
+
+#[test]
+fn test_nonce_form() {
+    let alphabet = &SpellingAlphabet::Nato;
+    let converter = PhoneticConverter::new(alphabet).nonce_form(true);
+    let input = "Example123";
+
+    assert_eq!(
+        converter.convert(input),
+        "'E' as in ECHO, 'x' as in x-ray, 'a' as in alfa, 'm' as in mike, 'p' as in papa, 'l' as \
+         in lima, 'e' as in echo, One, Two, Tree"
     );
 }

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -1,7 +1,9 @@
 use spellabet::{PhoneticConverter, SpellingAlphabet};
 
 fn main() {
-    let converter = PhoneticConverter::new(&SpellingAlphabet::Nato);
+    let alphabet = &SpellingAlphabet::Nato;
+    let converter = PhoneticConverter::new(alphabet);
     let input = "Hello, world!";
+
     println!("{}", converter.convert(input));
 }


### PR DESCRIPTION
Defaults to false (off), but when true (on) it will expand the output of letter conversions to include text like `'E' as in ECHO, 'x' as in x-ray, ...` where conversions of digits and symbols are not expanded.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
