### PR TITLE
Expand spellabet integration tests for better coverage

### DIFF
--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -10,21 +10,68 @@ fn test_convert() {
     let alphabet = &SpellingAlphabet::Nato;
     let converter = PhoneticConverter::new(alphabet);
 
+    // Test lowercase letters
+    assert_eq!(converter.convert("abc"), "alfa bravo charlie");
+
+    // Test uppercase letters
+    assert_eq!(converter.convert("ABC"), "ALFA BRAVO CHARLIE");
+
+    // Test mixed case letters
+    assert_eq!(converter.convert("AbC"), "ALFA bravo CHARLIE");
+
+    // Test digits
+    assert_eq!(converter.convert("123"), "One Two Tree");
+
+    // Test symbols
     assert_eq!(
-        converter.convert("Example123"),
-        "ECHO x-ray alfa mike papa lima echo One Two Tree"
+        converter.convert("a.b,c!"),
+        "alfa Period bravo Comma charlie Exclamation"
     );
+
+    // Test space character
+    assert_eq!(converter.convert(" "), "Space");
+
+    // Test empty string
+    assert_eq!(converter.convert(""), "");
+
+    // Test characters not in the conversion_map
+    assert_eq!(converter.convert("aΦb💩c"), "alfa Φ bravo 💩 charlie");
 }
 
 #[test]
 fn test_nonce_form() {
     let alphabet = &SpellingAlphabet::Nato;
-    let converter = PhoneticConverter::new(alphabet).nonce_form(true);
 
+    // Test with nonce_form = false
+    let converter = PhoneticConverter::new(alphabet).nonce_form(false);
+    assert_eq!(converter.convert("a"), "alfa");
+    assert_eq!(converter.convert("abc"), "alfa bravo charlie");
+    assert_eq!(converter.convert("ABC"), "ALFA BRAVO CHARLIE");
+    assert_eq!(converter.convert("123"), "One Two Tree");
+
+    // Test with nonce_form = true
+    let converter = PhoneticConverter::new(alphabet).nonce_form(true);
+    assert_eq!(converter.convert("a"), "'a' as in alfa");
     assert_eq!(
-        converter.convert("Example123"),
-        "'E' as in ECHO, 'x' as in x-ray, 'a' as in alfa, 'm' as in mike, 'p' as in papa, 'l' as \
-         in lima, 'e' as in echo, One, Two, Tree"
+        converter.convert("abc"),
+        "'a' as in alfa, 'b' as in bravo, 'c' as in charlie"
+    );
+    assert_eq!(
+        converter.convert("ABC"),
+        "'A' as in ALFA, 'B' as in BRAVO, 'C' as in CHARLIE"
+    );
+    assert_eq!(converter.convert("123"), "One, Two, Tree");
+
+    // Test mixed case letters
+    assert_eq!(
+        converter.convert("AbC"),
+        "'A' as in ALFA, 'b' as in bravo, 'C' as in CHARLIE"
+    );
+
+    // Test symbols
+    assert_eq!(
+        converter.convert("a.b,c!"),
+        "'a' as in alfa, Period, 'b' as in bravo, Comma, 'c' as in charlie, Exclamation"
     );
 }
 
@@ -40,7 +87,7 @@ fn test_with_overrides() {
     assert_eq!(converter.convert("c"), "charlie");
     assert_eq!(converter.convert("C"), "CHARLIE");
 
-    // Lowercase and uppercase keys will be normalized.
+    // Test that lowercase and uppercase keys will be normalized
     let mut overrides: HashMap<char, String> = HashMap::new();
     overrides.insert('a', "Able".to_string());
     overrides.insert('B', "Baker".to_string());


### PR DESCRIPTION
I may split some of these up, and I haven't covered unexpected inputs like control characters or special Unicode characters that are made of multiple combined characters, but this should be good enough to cover the core functionality. 

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [x] Added tests covering any code changes
