### PR TITLE
Split integration tests to be more granular

### DIFF
--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -5,53 +5,73 @@ use std::collections::HashMap;
 
 use spellabet::{PhoneticConverter, SpellingAlphabet};
 
-#[test]
-fn test_convert() {
+fn init_converter() -> PhoneticConverter {
     let alphabet = &SpellingAlphabet::Nato;
-    let converter = PhoneticConverter::new(alphabet);
+    PhoneticConverter::new(alphabet)
+}
 
-    // Test lowercase letters
+#[test]
+fn test_lowercase_letters() {
+    let converter = init_converter();
     assert_eq!(converter.convert("abc"), "alfa bravo charlie");
+}
 
-    // Test uppercase letters
+#[test]
+fn test_uppercase_letters() {
+    let converter = init_converter();
     assert_eq!(converter.convert("ABC"), "ALFA BRAVO CHARLIE");
+}
 
-    // Test mixed case letters
+#[test]
+fn test_mixed_case_letters() {
+    let converter = init_converter();
     assert_eq!(converter.convert("AbC"), "ALFA bravo CHARLIE");
+}
 
-    // Test digits
+#[test]
+fn test_digits() {
+    let converter = init_converter();
     assert_eq!(converter.convert("123"), "One Two Tree");
+}
 
-    // Test symbols
+#[test]
+fn test_symbols() {
+    let converter = init_converter();
     assert_eq!(
         converter.convert("a.b,c!"),
         "alfa Period bravo Comma charlie Exclamation"
     );
+}
 
-    // Test space character
+#[test]
+fn test_space_character() {
+    let converter = init_converter();
     assert_eq!(converter.convert(" "), "Space");
+}
 
-    // Test empty string
+#[test]
+fn test_empty_string() {
+    let converter = init_converter();
     assert_eq!(converter.convert(""), "");
+}
 
-    // Test characters not in the conversion_map
+#[test]
+fn test_unknown_characters() {
+    let converter = init_converter();
     assert_eq!(converter.convert("aΦb💩c"), "alfa Φ bravo 💩 charlie");
 }
 
 #[test]
-fn test_nonce_form() {
-    let alphabet = &SpellingAlphabet::Nato;
-
-    // Test with nonce_form = false
-    let converter = PhoneticConverter::new(alphabet).nonce_form(false);
-    assert_eq!(converter.convert("a"), "alfa");
+fn test_nonce_form_false() {
+    let converter = init_converter().nonce_form(false);
     assert_eq!(converter.convert("abc"), "alfa bravo charlie");
     assert_eq!(converter.convert("ABC"), "ALFA BRAVO CHARLIE");
-    assert_eq!(converter.convert("123"), "One Two Tree");
+    assert_eq!(converter.convert("AbC"), "ALFA bravo CHARLIE");
+}
 
-    // Test with nonce_form = true
-    let converter = PhoneticConverter::new(alphabet).nonce_form(true);
-    assert_eq!(converter.convert("a"), "'a' as in alfa");
+#[test]
+fn test_nonce_form_true() {
+    let converter = init_converter().nonce_form(true);
     assert_eq!(
         converter.convert("abc"),
         "'a' as in alfa, 'b' as in bravo, 'c' as in charlie"
@@ -60,15 +80,32 @@ fn test_nonce_form() {
         converter.convert("ABC"),
         "'A' as in ALFA, 'B' as in BRAVO, 'C' as in CHARLIE"
     );
-    assert_eq!(converter.convert("123"), "One, Two, Tree");
-
-    // Test mixed case letters
     assert_eq!(
         converter.convert("AbC"),
         "'A' as in ALFA, 'b' as in bravo, 'C' as in CHARLIE"
     );
+}
 
-    // Test symbols
+#[test]
+fn test_nonce_form_single_char() {
+    let converter = init_converter().nonce_form(true);
+    assert_eq!(converter.convert("a"), "'a' as in alfa");
+    assert_eq!(converter.convert("A"), "'A' as in ALFA");
+    assert_eq!(converter.convert("b"), "'b' as in bravo");
+    assert_eq!(converter.convert("B"), "'B' as in BRAVO");
+    assert_eq!(converter.convert("c"), "'c' as in charlie");
+    assert_eq!(converter.convert("C"), "'C' as in CHARLIE");
+}
+
+#[test]
+fn test_nonce_form_digits() {
+    let converter = init_converter().nonce_form(true);
+    assert_eq!(converter.convert("123"), "One, Two, Tree");
+}
+
+#[test]
+fn test_nonce_form_symbols() {
+    let converter = init_converter().nonce_form(true);
     assert_eq!(
         converter.convert("a.b,c!"),
         "'a' as in alfa, Period, 'b' as in bravo, Comma, 'c' as in charlie, Exclamation"
@@ -76,28 +113,62 @@ fn test_nonce_form() {
 }
 
 #[test]
-fn test_with_overrides() {
-    let alphabet = &SpellingAlphabet::Nato;
-    let mut converter = PhoneticConverter::new(alphabet);
-
+fn test_without_overrides() {
+    let converter = init_converter();
     assert_eq!(converter.convert("a"), "alfa");
     assert_eq!(converter.convert("A"), "ALFA");
     assert_eq!(converter.convert("b"), "bravo");
     assert_eq!(converter.convert("B"), "BRAVO");
     assert_eq!(converter.convert("c"), "charlie");
     assert_eq!(converter.convert("C"), "CHARLIE");
+    assert_eq!(converter.convert("abc"), "alfa bravo charlie");
+}
 
-    // Test that lowercase and uppercase keys will be normalized
+#[test]
+fn test_with_overrides() {
+    let mut converter = init_converter();
     let mut overrides: HashMap<char, String> = HashMap::new();
-    overrides.insert('a', "Able".to_string());
+    overrides.insert('A', "Able".to_string());
     overrides.insert('B', "Baker".to_string());
 
     converter = converter.with_overrides(overrides);
 
+    // Check that overrides worked
     assert_eq!(converter.convert("a"), "able");
     assert_eq!(converter.convert("A"), "ABLE");
     assert_eq!(converter.convert("b"), "baker");
     assert_eq!(converter.convert("B"), "BAKER");
+
+    // Check if non-overridden character is still using original conversion
     assert_eq!(converter.convert("c"), "charlie");
     assert_eq!(converter.convert("C"), "CHARLIE");
+    assert_eq!(converter.convert("abc"), "able baker charlie");
+}
+
+#[test]
+fn test_lowercase_key_in_overrides() {
+    let mut converter = init_converter();
+    let mut overrides: HashMap<char, String> = HashMap::new();
+    overrides.insert('c', "Cain".to_string());
+
+    converter = converter.with_overrides(overrides);
+
+    // Check that overrides map key was normalized
+    assert_eq!(converter.convert("c"), "cain");
+    assert_eq!(converter.convert("C"), "CAIN");
+    assert_eq!(converter.convert("abc"), "alfa bravo cain");
+}
+
+#[test]
+fn test_uppercase_key_in_overrides() {
+    let mut converter = init_converter();
+    let mut overrides: HashMap<char, String> = HashMap::new();
+    overrides.insert('C', "Cain".to_string());
+
+    converter = converter.with_overrides(overrides);
+
+    // Check that overrides map key was normalized
+    assert_eq!(converter.convert("c"), "cain");
+    assert_eq!(converter.convert("C"), "CAIN");
+    assert_eq!(converter.convert("abc"), "alfa bravo cain");
 }


### PR DESCRIPTION
Each test is now focused on one aspect of the functionality. This should make any failure cases more clear and easier to manage.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [x] Added tests covering any code changes
