### PR TITLE
Add tests covering each available spelling alphabet

### DIFF
--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -172,3 +172,45 @@ fn test_uppercase_key_in_overrides() {
     assert_eq!(converter.convert("C"), "CAIN");
     assert_eq!(converter.convert("abc"), "alfa bravo cain");
 }
+
+#[test]
+fn test_lapd_alphabet() {
+    let alphabet = &SpellingAlphabet::Lapd;
+    let converter = PhoneticConverter::new(alphabet);
+
+    assert_eq!(
+        converter.convert("abc123xyz"),
+        "adam boy charles One Two Three x-ray young zebra"
+    );
+
+    // Test non-default digits
+    assert_eq!(converter.convert("9"), "Niner");
+}
+
+#[test]
+fn test_nato_alphabet() {
+    let alphabet = &SpellingAlphabet::Nato;
+    let converter = PhoneticConverter::new(alphabet);
+
+    assert_eq!(
+        converter.convert("abc123xyz"),
+        "alfa bravo charlie One Two Tree x-ray yankee zulu"
+    );
+
+    // Test non-default digits
+    assert_eq!(converter.convert("3"), "Tree");
+    assert_eq!(converter.convert("4"), "Fower");
+    assert_eq!(converter.convert("5"), "Fife");
+    assert_eq!(converter.convert("9"), "Niner");
+}
+
+#[test]
+fn test_us_financial_alphabet() {
+    let alphabet = &SpellingAlphabet::UsFinancial;
+    let converter = PhoneticConverter::new(alphabet);
+
+    assert_eq!(
+        converter.convert("abc123xyz"),
+        "adam bob carol One Two Three xavier yogi zachary"
+    );
+}


### PR DESCRIPTION
This is a basic smoke test, but it does cover the non-default digits used by LAPD/NATO.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [x] Added tests covering any code changes
