### PR TITLE
Switch equality assertions over to Insta snapshot tests

### DIFF
--- a/.insta.yaml
+++ b/.insta.yaml
@@ -1,0 +1,2 @@
+test:
+  runner: "nextest"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,7 @@ For example:
   cargo xtask coverage.html
   ```
 
-- Run all tests via Nextest and generate/review snapshots
+- Run all tests via Nextest and collect Insta snapshots
 
   ```
   cargo xtask test
@@ -274,14 +274,13 @@ Most other commands are the same as any standard Rust project:
   cargo +nightly fmt
   ```
 
-- Run tests and doctests
+- Run the tests
 
   ```
-  cargo nextest run
-  cargo test --doc
+  cargo test
   ```
 
-- Build and run the release version:
+- Build and run the release binary:
 
   ```
   cargo run --release --bin spellout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "insta"
+version = "1.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a28d25139df397cbca21408bb742cf6837e04cdbebf1b07b760caf971d6a972"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexopt"
@@ -31,6 +68,12 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "nanoserde"
@@ -54,8 +97,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
 name = "spellabet"
 version = "0.1.0"
+dependencies = [
+ "insta",
+]
 
 [[package]]
 name = "spellout"
@@ -74,6 +126,72 @@ dependencies = [
  "libc",
  "once_cell",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "xshell"
@@ -100,4 +218,13 @@ dependencies = [
  "nanoserde",
  "which",
  "xshell",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ license = "MIT OR Apache-2.0"
 # and we don't rely on it for debugging that much.
 debug = 0
 
+[profile.dev.package.insta]
+opt-level = 3
+
+[profile.dev.package.similar]
+opt-level = 3
+
 [profile.release]
 lto = "thin"
 

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -12,3 +12,6 @@ repository = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellab
 license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dev-dependencies]
+insta = "1.29.0"

--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 
+use insta::assert_snapshot;
 use spellabet::{PhoneticConverter, SpellingAlphabet};
 
 fn init_converter() -> PhoneticConverter {
@@ -13,115 +14,115 @@ fn init_converter() -> PhoneticConverter {
 #[test]
 fn test_lowercase_letters() {
     let converter = init_converter();
-    assert_eq!(converter.convert("abc"), "alfa bravo charlie");
+    assert_snapshot!(converter.convert("abc"), @"alfa bravo charlie");
 }
 
 #[test]
 fn test_uppercase_letters() {
     let converter = init_converter();
-    assert_eq!(converter.convert("ABC"), "ALFA BRAVO CHARLIE");
+    assert_snapshot!(converter.convert("ABC"), @"ALFA BRAVO CHARLIE");
 }
 
 #[test]
 fn test_mixed_case_letters() {
     let converter = init_converter();
-    assert_eq!(converter.convert("AbC"), "ALFA bravo CHARLIE");
+    assert_snapshot!(converter.convert("AbC"), @"ALFA bravo CHARLIE");
 }
 
 #[test]
 fn test_digits() {
     let converter = init_converter();
-    assert_eq!(converter.convert("123"), "One Two Tree");
+    assert_snapshot!(converter.convert("123"), @"One Two Tree");
 }
 
 #[test]
 fn test_symbols() {
     let converter = init_converter();
-    assert_eq!(
+    assert_snapshot!(
         converter.convert("a.b,c!"),
-        "alfa Period bravo Comma charlie Exclamation"
+        @"alfa Period bravo Comma charlie Exclamation"
     );
 }
 
 #[test]
 fn test_space_character() {
     let converter = init_converter();
-    assert_eq!(converter.convert(" "), "Space");
+    assert_snapshot!(converter.convert(" "), @"Space");
 }
 
 #[test]
 fn test_empty_string() {
     let converter = init_converter();
-    assert_eq!(converter.convert(""), "");
+    assert_snapshot!(converter.convert(""), @"");
 }
 
 #[test]
 fn test_unknown_characters() {
     let converter = init_converter();
-    assert_eq!(converter.convert("aΦb💩c"), "alfa Φ bravo 💩 charlie");
+    assert_snapshot!(converter.convert("aΦb💩c"), @"alfa Φ bravo 💩 charlie");
 }
 
 #[test]
 fn test_nonce_form_false() {
     let converter = init_converter().nonce_form(false);
-    assert_eq!(converter.convert("abc"), "alfa bravo charlie");
-    assert_eq!(converter.convert("ABC"), "ALFA BRAVO CHARLIE");
-    assert_eq!(converter.convert("AbC"), "ALFA bravo CHARLIE");
+    assert_snapshot!(converter.convert("abc"), @"alfa bravo charlie");
+    assert_snapshot!(converter.convert("ABC"), @"ALFA BRAVO CHARLIE");
+    assert_snapshot!(converter.convert("AbC"), @"ALFA bravo CHARLIE");
 }
 
 #[test]
 fn test_nonce_form_true() {
     let converter = init_converter().nonce_form(true);
-    assert_eq!(
+    assert_snapshot!(
         converter.convert("abc"),
-        "'a' as in alfa, 'b' as in bravo, 'c' as in charlie"
+        @"'a' as in alfa, 'b' as in bravo, 'c' as in charlie"
     );
-    assert_eq!(
+    assert_snapshot!(
         converter.convert("ABC"),
-        "'A' as in ALFA, 'B' as in BRAVO, 'C' as in CHARLIE"
+        @"'A' as in ALFA, 'B' as in BRAVO, 'C' as in CHARLIE"
     );
-    assert_eq!(
+    assert_snapshot!(
         converter.convert("AbC"),
-        "'A' as in ALFA, 'b' as in bravo, 'C' as in CHARLIE"
+        @"'A' as in ALFA, 'b' as in bravo, 'C' as in CHARLIE"
     );
 }
 
 #[test]
 fn test_nonce_form_single_char() {
     let converter = init_converter().nonce_form(true);
-    assert_eq!(converter.convert("a"), "'a' as in alfa");
-    assert_eq!(converter.convert("A"), "'A' as in ALFA");
-    assert_eq!(converter.convert("b"), "'b' as in bravo");
-    assert_eq!(converter.convert("B"), "'B' as in BRAVO");
-    assert_eq!(converter.convert("c"), "'c' as in charlie");
-    assert_eq!(converter.convert("C"), "'C' as in CHARLIE");
+    assert_snapshot!(converter.convert("a"), @"'a' as in alfa");
+    assert_snapshot!(converter.convert("A"), @"'A' as in ALFA");
+    assert_snapshot!(converter.convert("b"), @"'b' as in bravo");
+    assert_snapshot!(converter.convert("B"), @"'B' as in BRAVO");
+    assert_snapshot!(converter.convert("c"), @"'c' as in charlie");
+    assert_snapshot!(converter.convert("C"), @"'C' as in CHARLIE");
 }
 
 #[test]
 fn test_nonce_form_digits() {
     let converter = init_converter().nonce_form(true);
-    assert_eq!(converter.convert("123"), "One, Two, Tree");
+    assert_snapshot!(converter.convert("123"), @"One, Two, Tree");
 }
 
 #[test]
 fn test_nonce_form_symbols() {
     let converter = init_converter().nonce_form(true);
-    assert_eq!(
+    assert_snapshot!(
         converter.convert("a.b,c!"),
-        "'a' as in alfa, Period, 'b' as in bravo, Comma, 'c' as in charlie, Exclamation"
+        @"'a' as in alfa, Period, 'b' as in bravo, Comma, 'c' as in charlie, Exclamation"
     );
 }
 
 #[test]
 fn test_without_overrides() {
     let converter = init_converter();
-    assert_eq!(converter.convert("a"), "alfa");
-    assert_eq!(converter.convert("A"), "ALFA");
-    assert_eq!(converter.convert("b"), "bravo");
-    assert_eq!(converter.convert("B"), "BRAVO");
-    assert_eq!(converter.convert("c"), "charlie");
-    assert_eq!(converter.convert("C"), "CHARLIE");
-    assert_eq!(converter.convert("abc"), "alfa bravo charlie");
+    assert_snapshot!(converter.convert("a"), @"alfa");
+    assert_snapshot!(converter.convert("A"), @"ALFA");
+    assert_snapshot!(converter.convert("b"), @"bravo");
+    assert_snapshot!(converter.convert("B"), @"BRAVO");
+    assert_snapshot!(converter.convert("c"), @"charlie");
+    assert_snapshot!(converter.convert("C"), @"CHARLIE");
+    assert_snapshot!(converter.convert("abc"), @"alfa bravo charlie");
 }
 
 #[test]
@@ -134,15 +135,15 @@ fn test_with_overrides() {
     converter = converter.with_overrides(overrides);
 
     // Check that overrides worked
-    assert_eq!(converter.convert("a"), "able");
-    assert_eq!(converter.convert("A"), "ABLE");
-    assert_eq!(converter.convert("b"), "baker");
-    assert_eq!(converter.convert("B"), "BAKER");
+    assert_snapshot!(converter.convert("a"), @"able");
+    assert_snapshot!(converter.convert("A"), @"ABLE");
+    assert_snapshot!(converter.convert("b"), @"baker");
+    assert_snapshot!(converter.convert("B"), @"BAKER");
 
     // Check if non-overridden character is still using original conversion
-    assert_eq!(converter.convert("c"), "charlie");
-    assert_eq!(converter.convert("C"), "CHARLIE");
-    assert_eq!(converter.convert("abc"), "able baker charlie");
+    assert_snapshot!(converter.convert("c"), @"charlie");
+    assert_snapshot!(converter.convert("C"), @"CHARLIE");
+    assert_snapshot!(converter.convert("abc"), @"able baker charlie");
 }
 
 #[test]
@@ -154,9 +155,9 @@ fn test_lowercase_key_in_overrides() {
     converter = converter.with_overrides(overrides);
 
     // Check that overrides map key was normalized
-    assert_eq!(converter.convert("c"), "cain");
-    assert_eq!(converter.convert("C"), "CAIN");
-    assert_eq!(converter.convert("abc"), "alfa bravo cain");
+    assert_snapshot!(converter.convert("c"), @"cain");
+    assert_snapshot!(converter.convert("C"), @"CAIN");
+    assert_snapshot!(converter.convert("abc"), @"alfa bravo cain");
 }
 
 #[test]
@@ -168,9 +169,9 @@ fn test_uppercase_key_in_overrides() {
     converter = converter.with_overrides(overrides);
 
     // Check that overrides map key was normalized
-    assert_eq!(converter.convert("c"), "cain");
-    assert_eq!(converter.convert("C"), "CAIN");
-    assert_eq!(converter.convert("abc"), "alfa bravo cain");
+    assert_snapshot!(converter.convert("c"), @"cain");
+    assert_snapshot!(converter.convert("C"), @"CAIN");
+    assert_snapshot!(converter.convert("abc"), @"alfa bravo cain");
 }
 
 #[test]
@@ -178,13 +179,13 @@ fn test_lapd_alphabet() {
     let alphabet = &SpellingAlphabet::Lapd;
     let converter = PhoneticConverter::new(alphabet);
 
-    assert_eq!(
+    assert_snapshot!(
         converter.convert("abc123xyz"),
-        "adam boy charles One Two Three x-ray young zebra"
+        @"adam boy charles One Two Three x-ray young zebra"
     );
 
     // Test non-default digits
-    assert_eq!(converter.convert("9"), "Niner");
+    assert_snapshot!(converter.convert("9"), @"Niner");
 }
 
 #[test]
@@ -192,16 +193,16 @@ fn test_nato_alphabet() {
     let alphabet = &SpellingAlphabet::Nato;
     let converter = PhoneticConverter::new(alphabet);
 
-    assert_eq!(
+    assert_snapshot!(
         converter.convert("abc123xyz"),
-        "alfa bravo charlie One Two Tree x-ray yankee zulu"
+        @"alfa bravo charlie One Two Tree x-ray yankee zulu"
     );
 
     // Test non-default digits
-    assert_eq!(converter.convert("3"), "Tree");
-    assert_eq!(converter.convert("4"), "Fower");
-    assert_eq!(converter.convert("5"), "Fife");
-    assert_eq!(converter.convert("9"), "Niner");
+    assert_snapshot!(converter.convert("3"), @"Tree");
+    assert_snapshot!(converter.convert("4"), @"Fower");
+    assert_snapshot!(converter.convert("5"), @"Fife");
+    assert_snapshot!(converter.convert("9"), @"Niner");
 }
 
 #[test]
@@ -209,8 +210,8 @@ fn test_us_financial_alphabet() {
     let alphabet = &SpellingAlphabet::UsFinancial;
     let converter = PhoneticConverter::new(alphabet);
 
-    assert_eq!(
+    assert_snapshot!(
         converter.convert("abc123xyz"),
-        "adam bob carol One Two Three xavier yogi zachary"
+        @"adam bob carol One Two Three xavier yogi zachary"
     );
 }

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -33,7 +33,7 @@ pub fn test_with_snapshots(config: &Config) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
-        let args = vec!["insta", "test", "--test-runner", "nextest", "--review"];
+        let args = vec!["insta", "test", "--test-runner", "nextest"];
         cmd.args(args).run()?;
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -33,7 +33,7 @@ TASKS:
     fixup.rust             Fix lints and format Rust files in-place
     fixup.spelling         Fix common misspellings across all files in-place
     install                Install required Rust components and Cargo dependencies
-    test                   Run all tests via Nextest and generate/review snapshots
+    test                   Run all tests via Nextest and collect Insta snapshots
 ";
 
 enum Task {


### PR DESCRIPTION
This will make any output changes much easier to review and update. Unfortunately, this also uncovered an issue with trying to run the tests with the `--review` flag via our `cargo xtask test` wrapper, as once the interactive review process starts, it would panic with:

> Too many open files (os error 24)

So we can just run the test command, which will fail if there is a snapshot needing review, and then run `cargo insta review` afterward.

See:
- https://insta.rs/

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
