### PR TITLE
Parse environment variables for spellout arguments

### DIFF
--- a/crates/spellout/Cargo.toml
+++ b/crates/spellout/Cargo.toml
@@ -14,5 +14,5 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3.0", features = ["derive"] }
+clap = { version = "4.3.0", features = ["derive", "env"] }
 spellabet = { path = "../spellabet" }

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -5,11 +5,13 @@ use spellabet::{PhoneticConverter, SpellingAlphabet};
 #[command(author, version, about, long_about = None)]
 struct Cli {
     /// Which spelling alphabet to use for the conversion
-    #[arg(short, long, value_enum, default_value_t = Alphabet::Nato)]
+    #[arg(short, long, env = "SPELLOUT_ALPHABET")]
+    #[arg(value_enum, default_value_t = Alphabet::Nato)]
     alphabet: Alphabet,
 
     /// Expand output into nonce form like "'A' as in ALFA"
-    #[arg(short, long)]
+    #[arg(short, long, env = "SPELLOUT_NONCE_FORM")]
+    #[arg(value_parser = clap::builder::BoolishValueParser::new())]
     nonce_form: bool,
 
     /// The input characters to convert into code words


### PR DESCRIPTION
These are namespaced by the `SPELLOUT_` prefix and any directly-supplied arguments take precedence over the environment variables.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
