### PR TITLE
Allow configuring verbose via an environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -335,6 +336,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/spellout/Cargo.toml
+++ b/crates/spellout/Cargo.toml
@@ -14,5 +14,5 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3.0", features = ["derive", "env"] }
+clap = { version = "4.3.0", features = ["derive", "env", "wrap_help"] }
 spellabet = { path = "../spellabet" }

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -25,7 +25,8 @@ struct Cli {
     dump_alphabet: bool,
 
     /// Use verbose output
-    #[arg(short, long)]
+    #[arg(short, long, env = "SPELLOUT_VERBOSE")]
+    #[arg(value_parser = clap::builder::BoolishValueParser::new())]
     verbose: bool,
 
     /// The input character string to convert into code words


### PR DESCRIPTION
Since the default `-h` output can get pretty long, we'll also pull in the `wrap_help` feature for detecting the terminal width and adjusting help output accordingly.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
