### PR TITLE
Read input strings from stdin when none were given directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,7 @@ name = "spellout"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "is-terminal",
  "spellabet",
 ]
 

--- a/crates/spellout/Cargo.toml
+++ b/crates/spellout/Cargo.toml
@@ -15,4 +15,5 @@ license.workspace = true
 
 [dependencies]
 clap = { version = "4.3.0", features = ["derive", "env", "wrap_help"] }
+is-terminal = "0.4.7"
 spellabet = { path = "../spellabet" }


### PR DESCRIPTION
This was very tricky to get right as I still wanted to have the nice clap error message about missing a required argument if there were no strings supplied via stdin or the normal arguments.

See:
- https://github.com/clap-rs/clap/discussions/3437
- https://github.com/clap-rs/clap/discussions/4539

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
