### PR TITLE
Add flag to parse user overrides for code words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +319,7 @@ checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 name = "spellabet"
 version = "0.1.0"
 dependencies = [
+ "convert_case",
  "insta",
 ]
 
@@ -317,6 +327,7 @@ dependencies = [
 name = "spellout"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "is-terminal",
  "spellabet",
@@ -354,6 +365,12 @@ name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "utf8parse"

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -13,5 +13,8 @@ license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dependencies]
+convert_case = "0.6.0"
+
 [dev-dependencies]
 insta = "1.29.0"

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 
 use code_words::{DEFAULT_DIGITS_AND_SYMBOLS, LAPD_ALPHABET, NATO_ALPHABET, US_FINANCIAL_ALPHABET};
+use convert_case::{Case, Casing};
 
 mod code_words;
 
@@ -36,10 +37,15 @@ impl PhoneticConverter {
     }
 
     #[must_use]
+    pub const fn mappings(&self) -> &HashMap<char, String> {
+        &self.conversion_map
+    }
+
+    #[must_use]
     pub fn with_overrides(mut self, overrides: HashMap<char, String>) -> Self {
         let lower_overrides: HashMap<char, String> = overrides
             .into_iter()
-            .map(|(k, v)| (k.to_ascii_lowercase(), v))
+            .map(|(k, v)| (k.to_ascii_lowercase(), v.to_case(Case::Pascal)))
             .collect();
 
         self.conversion_map.extend(lower_overrides);
@@ -64,24 +70,24 @@ impl PhoneticConverter {
         result
     }
 
-    fn convert_char(&self, c: char, result: &mut String) {
-        match self.conversion_map.get(&c.to_ascii_lowercase()) {
+    fn convert_char(&self, character: char, result: &mut String) {
+        match self.conversion_map.get(&character.to_ascii_lowercase()) {
             Some(word) => {
-                let code_word = if c.is_lowercase() {
+                let code_word = if character.is_lowercase() {
                     word.to_lowercase()
-                } else if c.is_uppercase() {
+                } else if character.is_uppercase() {
                     word.to_uppercase()
                 } else {
                     word.clone()
                 };
 
-                if self.nonce_form && c.is_alphabetic() {
-                    result.push_str(&format!("'{c}' as in {code_word}"));
+                if self.nonce_form && character.is_alphabetic() {
+                    result.push_str(&format!("'{character}' as in {code_word}"));
                 } else {
                     result.push_str(&code_word);
                 }
             }
-            None => result.push(c),
+            None => result.push(character),
         }
     }
 }

--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -175,6 +175,28 @@ fn test_uppercase_key_in_overrides() {
 }
 
 #[test]
+fn test_overrides_value_normalization() {
+    let mut converter = init_converter();
+    let mut overrides: HashMap<char, String> = HashMap::new();
+    overrides.insert('-', "hyphen".to_string());
+    overrides.insert('/', "SLANT".to_string());
+    overrides.insert('(', "brackets on".to_string());
+    overrides.insert(')', "bracketsOff".to_string());
+    overrides.insert('!', "exclamation-mark".to_string());
+    overrides.insert('?', "question_mark".to_string());
+
+    converter = converter.with_overrides(overrides);
+
+    // Check that overrides map value was normalized
+    assert_snapshot!(converter.convert("-"), @"Hyphen");
+    assert_snapshot!(converter.convert("/"), @"Slant");
+    assert_snapshot!(converter.convert("("), @"BracketsOn");
+    assert_snapshot!(converter.convert(")"), @"BracketsOff");
+    assert_snapshot!(converter.convert("!"), @"ExclamationMark");
+    assert_snapshot!(converter.convert("?"), @"QuestionMark");
+}
+
+#[test]
 fn test_lapd_alphabet() {
     let alphabet = SpellingAlphabet::Lapd;
     let converter = PhoneticConverter::new(&alphabet);

--- a/crates/spellout/Cargo.toml
+++ b/crates/spellout/Cargo.toml
@@ -14,6 +14,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.71"
 clap = { version = "4.3.0", features = ["derive", "env", "wrap_help"] }
 is-terminal = "0.4.7"
 spellabet = { path = "../spellabet" }


### PR DESCRIPTION
I had to add the ability to get the mappings from a `PhoneticConverter` since that's where we define overrides (not on `SpellingAlphabet`'s directly) and we also need the `--dump-alphabet` flag to display them accordingly.

The one caveat to the current parsing code is that it won't let users override a comma (',') or equal sign ('=') since it uses those characters to parse the string argument and does not support escaping. It could be addressed eventually, but would make the code more complex.

To improve the user experience and ensure consistency, we're also normalizing the conversion map values to always be pascal case. The convert_case crate we're using properly handles a number of different forms of input.

See:
- https://crates.io/crates/convert_case/

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
