### PR TITLE
Keep user input at end of error output

### DIFF
--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -120,10 +120,10 @@ fn parse_overrides(input: &str) -> Result<HashMap<char, String>> {
         let parts: Vec<&str> = s.split('=').collect();
 
         if parts.len() < 2 {
-            anyhow::bail!("Invalid override: {s} (missing '=')");
+            anyhow::bail!("Invalid override (missing '='): {s}");
         }
         if parts.len() > 2 {
-            anyhow::bail!("Invalid override: {s} (extra '=')");
+            anyhow::bail!("Invalid override (extra '='): {s}");
         }
         if parts[0].len() != 1 {
             anyhow::bail!("Key in override is not a single character: {s}");


### PR DESCRIPTION
This makes it a bit easier to read and understand when the user input that is causing an error isn't sandwiched in the middle of the error output message. I tried creating custom clap errors, but I actually didn't like the output as much and I don't mind having a distinction between output for clap-related errors and errors with my own parsing code.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
