### PR TITLE
Render usage line when no input string was provided

### DIFF
--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -85,11 +85,12 @@ fn main() -> Result<()> {
         }
     } else if io::stdin().is_terminal() {
         // The user did not provide an input string argument nor data piped from stdin
-        let cmd = Cli::command();
+        let mut cmd = Cli::command();
+        eprintln!("{}\n", cmd.render_usage());
         let mut err = clap::Error::new(ErrorKind::MissingRequiredArgument).with_cmd(&cmd);
         err.insert(
             ContextKind::InvalidArg,
-            ContextValue::Strings(vec!["<STRING>...".to_string()]),
+            ContextValue::Strings(vec!["[STRING]...".to_string()]),
         );
         err.exit();
     } else {


### PR DESCRIPTION
The error output from running a bare `spellout` wasn't 100% clear without some context surrounding the expected usage.

Before:
```
$ spellout
error: the following required arguments were not provided:
  <STRING>...

For more information, try '--help'.
```

After:
```
$ spellout
Usage: spellout [OPTIONS] [STRING]...

error: the following required arguments were not provided:
  [STRING]...

For more information, try '--help'.
```

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
