### PR TITLE
Expand the README with details on CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,109 @@
 
 ---
 
+spellout is a command-line application for transforming text strings into their
+equivalent code words based on predefined [spelling alphabets][]. These spelling
+alphabets, such as the NATO phonetic alphabet, are designed to boost verbal
+clarity, particluarly when spelling out words over low-fidelity voice channels.
+The application supports multiple standard alphabets and allows for
+customization to suit specific communication needs.
+
+In its operation, spellout will maintain the original capitalization of letters
+by returning either lowercase or uppercase code words. Known digits and other
+symbols undergo the same conversion process into code words. Unrecognized
+characters are returned as is, without conversion.
+
+[spelling alphabets]: https://en.wikipedia.org/wiki/Spelling_alphabet
+
 ## Usage
 
+    Usage: spellout [OPTIONS] [STRING]...
+
+    Arguments:
+      [STRING]...  An input character string to convert into code words
+
+    Options:
+      -a, --alphabet <ALPHABET>    Which spelling alphabet to use for the conversion
+      -o, --overrides <OVERRIDES>  Define overrides for spelling alphabet code words
+          --dump-alphabet          Display the spelling alphabet and exit
+      -n, --nonce-form             Expand output into nonce form like "'A' as in ALFA"
+      -v, --verbose                Use verbose output
+      -h, --help                   Print help (see more with '--help')
+      -V, --version                Print version
+
+Each string will have its output printed on a separate line, and spellout will
+honor using `--` to stop interpreting the subsequent arguments as options.
+
+### Examples
+
     $ spellout Example123
-    ECHO x-ray alpha mike papa lima echo One Two Three
+    ECHO x-ray alpha mike papa lima echo One Two Tree
+
+    $ spellout --alphabet us-financial Example123
+    EDDIE xavier adam mary peter larry eddie One Two Three
+
+    $ spellout --nonce-form Rust
+    'R' as in ROMEO, 'u' as in uniform, 's' as in sierra, 't' as in tango
+
+    $ spellout --verbose Aaron "Bull Schaefer"
+    Aaron -> ALFA alfa romeo oscar november
+    Bull Schaefer -> BRAVO uniform lima lima Space SIERRA charlie hotel alfa echo foxtrot echo romeo
+
+    $ spellout -- --help
+    Dash Dash hotel echo lima papa
+
+    $ spellout "So 📞 me, maybe?"
+    SIERRA oscar Space 📞 Space mike echo Comma Space mike alfa yankee bravo echo Question
+
+spellout will also read lines from standard input (stdin):
+
+    $ cat secrets | spellout --verbose
+    4PN%mAnt -> Fower PAPA NOVEMBER Percent mike ALFA november tango
+    5Jzd}y(d -> Fife JULIETT zulu delta RightBrace yankee LeftParens delta
+    BTW{2J~l -> BRAVO TANGO WHISKEY LeftBrace Two JULIETT Tilde lima
+
+### Environment Variables
+
+Some options can alternatively be provided by setting environment variables (the
+command-line arguments take precedence). To set the variables, use:
+`export VARNAME=value`, where `VARNAME` is the name of the environment variable
+and `value` is the desired setting.
+
+#### `SPELLOUT_ALPHABET`
+
+This environment variable determines the spelling alphabet to use for the
+conversion.
+
+Default: `nato`
+
+Possible values:
+
+- `lapd`: Use the Los Angeles Police Department (LAPD) spelling alphabet.
+- `nato`: Use the North Atlantic Treaty Organization (NATO) spelling alphabet.
+  This is the default setting.
+- `us-financial`: Use the United States Financial Industry spelling alphabet.
+
+#### `SPELLOUT_OVERRIDES`
+
+Default: None
+
+This environment variable allows you to define overrides for spelling alphabet
+code words. Provide a comma-separated list of _character=word_ pairs like
+`"a=apple,b=banana"`.
+
+#### `SPELLOUT_NONCE_FORM`
+
+Default: `false`
+
+Setting this environment variable to any non-falsey value enables the nonce form
+output, which expands conversions into a form like "'A' as in ALFA".
+
+#### `SPELLOUT_VERBOSE`
+
+Default: `false`
+
+Setting this environment variable to any non-falsey value enables the verbose
+output, which will include the input characters along with each line's output.
 
 ## Installation
 

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -31,12 +31,14 @@ struct Cli {
 
     /// Expand output into nonce form like "'A' as in ALFA"
     #[arg(short, long, env = "SPELLOUT_NONCE_FORM")]
-    #[arg(value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(value_parser = clap::builder::FalseyValueParser::new())]
     nonce_form: bool,
 
     /// Use verbose output
+    ///
+    /// Include the input characters along with each line's output.
     #[arg(short, long, env = "SPELLOUT_VERBOSE")]
-    #[arg(value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(value_parser = clap::builder::FalseyValueParser::new())]
     verbose: bool,
 
     /// An input character string to convert into code words


### PR DESCRIPTION
Writing out the details for the environment variables that expect a boolean value made me realize that we also don't need the full functionality of clap's BoolishValueParser. Since the default is already false, we can assume everything that's not "falsey" should be considered true rather than throwing an error to the end user. That should more closely match their intension and improve the user experience.

See:
- https://docs.rs/clap/latest/clap/builder/struct.FalseyValueParser.html

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
