### PR TITLE
Move MSRV documentation into spellabet lib README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# spellout &emsp; [![CI Status]][actions] [![MSRV]][rust-version]
+# spellout &emsp; [![CI Status]][actions]
 
 [CI Status]:
   https://img.shields.io/github/actions/workflow/status/EarthmanMuons/spellout/rust.yml?event=merge_group&label=CI&logo=github
 [actions]:
   https://github.com/EarthmanMuons/spellout/actions?query=event%3Amerge_group
-[MSRV]: https://img.shields.io/badge/MSRV-1.64-blue
-[rust-version]:
-  https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
 
 **Convert characters into their equivalent spelling alphabet code words.**
 
@@ -124,15 +121,6 @@ directory, run the following command:
 ```
 cargo install --locked --git https://github.com/EarthmanMuons/spellout/ spellout
 ```
-
-## Minimum Supported Rust Version (MSRV) Policy
-
-- We follow an "N-2 policy," supporting at least the current stable Rust release
-  and the two preceding versions.
-- Our MSRV only advances when we adopt a feature from a newer Rust version. We
-  do not increase the MSRV systematically with each new release of Rust.
-- MSRV increases are considered regular changes, not breaking changes, in terms
-  of Semantic Versioning.
 
 ## Credits
 

--- a/crates/spellabet/README.md
+++ b/crates/spellabet/README.md
@@ -1,4 +1,12 @@
-# spellabet
+# spellabet &emsp; [![MSRV]][rust-version]
+
+[MSRV]: https://img.shields.io/badge/MSRV-1.64-blue
+[rust-version]:
+  https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
+
+**Convert characters into their equivalent spelling alphabet code words.**
+
+---
 
 spellabet is a Rust library for transforming text strings into their equivalent
 code words based on predefined [spelling alphabets][]. These spelling alphabets,
@@ -29,6 +37,15 @@ Generated [Rustdoc][] reference documentation can be found at
 <https://earthmanmuons.github.io/spellout/spellabet/index.html>
 
 [Rustdoc]: https://doc.rust-lang.org/stable/rustdoc/
+
+## Minimum Supported Rust Version (MSRV) Policy
+
+- We follow an "N-2 policy," supporting at least the current stable Rust release
+  and the two preceding versions.
+- Our MSRV only advances when we adopt a feature from a newer Rust version. We
+  do not increase the MSRV systematically with each new release of Rust.
+- MSRV increases are considered regular changes, not breaking changes, in terms
+  of Semantic Versioning.
 
 ## License
 


### PR DESCRIPTION
Users of the spellout binary aren't likely to care much about the Rust- specific policies, like users of the library would. It probably doesn't need to be duplicated in both documents.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
