### PR TITLE
Document the entire spellabet library

### DIFF
--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -10,6 +10,8 @@ readme.workspace = true
 homepage = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellabet"
 repository = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellabet"
 license.workspace = true
+keywords = ["formatting", "humanize", "text"]
+categories = ["text-processing", "value-formatting"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/spellabet/README.md
+++ b/crates/spellabet/README.md
@@ -24,110 +24,30 @@ characters are returned as is, without conversion.
 
 ## Usage
 
-To use the library, add it as dependency in your `Cargo.toml` file:
+To use the crate, add it as dependency in your `Cargo.toml` file:
 
 ```toml
 [dependencies]
 spellabet = "0.1.0"
 ```
 
-Then, import the `PhoneticConverter` struct into your Rust code:
+### Example
 
 ```rust
 use spellabet::{PhoneticConverter, SpellingAlphabet};
+
+let converter = PhoneticConverter::new(&SpellingAlphabet::Nato);
+println!("{}", converter.convert("Example123!"));
 ```
 
-### Creating a Converter
-
-To create a `PhoneticConverter` instance, use the `new` method and specify the
-desired spelling alphabet:
-
-```rust
-let alphabet = SpellingAlphabet::default();
-let converter = PhoneticConverter::new(&alphabet);
 ```
-
-#### Alphabet Options
-
-The library supports the following spelling alphabets:
-
-- `SpellingAlphabet::Lapd`: The LAPD (Los Angeles Police Department) spelling
-  alphabet.
-- `SpellingAlphabet::Nato`: The NATO (North Atlantic Treaty Organization)
-  spelling alphabet (default).
-- `SpellingAlphabet::UsFinancial`: The United States Financial Industry spelling
-  alphabet.
-
-### Converting Characters
-
-To convert characters into their spelling alphabet code words, use the `convert`
-method:
-
-```rust
-let text = "Hello";
-let result = converter.convert(text);
-println!("Result: {result}");
-```
-
-The above code will output:
-
-```
-Result: HOTEL echo lima lima oscar
-```
-
-### Nonce Form
-
-The `PhoneticConverter` also supports "nonce form" where each converted
-character is expanded into the form "'A' as in ALFA". To enable the nonce form
-output, use the `nonce_form` method:
-
-```rust
-let converter = converter.nonce_form(true)
-```
-
-### Customizing the Conversion Map
-
-You can override characters in the default conversion map by using the
-`with_overrides` method and providing a `HashMap<char, String>` containing the
-desired mappings:
-
-```rust
-use std::collections::HashMap;
-
-let mut overrides = HashMap::new();
-overrides.insert('A', "Apple".to_string());
-overrides.insert('B', "Banana".to_string());
-
-let converter = converter.with_overrides(overrides);
-```
-
-### Dumping the Conversion Map
-
-To dump the current conversion map, you can use the `dump_alphabet` method. It
-writes the map to a provided writer.
-
-```rust
-use std::fs::File;
-use std::io::Write;
-
-let mut file = File::create("alphabet.txt")?;
-converter.dump_alphabet(&mut file, false)?;
-```
-
-This will create a file named "alphabet.txt" with the following content:
-
-```
-A -> Alfa
-B -> Bravo
-...
+ECHO x-ray alfa mike papa lima echo One Two Tree Exclamation
 ```
 
 ## Documentation
 
-Generated [Rustdoc][] reference documentation can be found at
+Detailed examples and generated API reference documentation can be found at
 <https://earthmanmuons.github.io/spellout/spellabet/index.html>
-
-[Rustdoc]: https://doc.rust-lang.org/stable/rustdoc/
 
 ## Minimum Supported Rust Version (MSRV) Policy
 

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -1,6 +1,29 @@
 #![deny(clippy::all)]
 #![warn(clippy::nursery, clippy::pedantic)]
 
+//! # Spelling Alphabet
+//!
+//! A library for converting text string characters into their equivalent
+//! [spelling alphabet](https://en.wikipedia.org/wiki/Spelling_alphabet) code words.
+//!
+//! In its operation, spellabet will maintain the original capitalization of
+//! letters by returning either lowercase or uppercase code words. Known digits
+//! and other symbols undergo the same conversion process into code words.
+//! Unrecognized characters are returned as is, without conversion.
+//!
+//! # Example
+//!
+//! ```
+//! use spellabet::{PhoneticConverter, SpellingAlphabet};
+//!
+//! let converter = PhoneticConverter::new(&SpellingAlphabet::Nato);
+//! println!("{}", converter.convert("Example123!"));
+//! ```
+//!
+//! ```text
+//! ECHO x-ray alfa mike papa lima echo One Two Tree Exclamation
+//! ```
+
 use std::char;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -10,20 +33,43 @@ use convert_case::{Case, Casing};
 
 mod code_words;
 
+/// A phonetic converter.
 pub struct PhoneticConverter {
+    /// The map of characters to code words.
     conversion_map: HashMap<char, String>,
+    /// Is set when the code word output will be in "nonce form".
     nonce_form: bool,
 }
 
+/// A spelling alphabet.
 #[derive(Default)]
 pub enum SpellingAlphabet {
+    /// The LAPD (Los Angeles Police Department) spelling alphabet.
     Lapd,
+    /// The NATO (North Atlantic Treaty Organization) spelling alphabet.
+    /// This is the default.
     #[default]
     Nato,
+    /// The United States Financial Industry spelling alphabet.
     UsFinancial,
 }
 
 impl PhoneticConverter {
+    /// Creates and returns a new instance of `PhoneticConverter` using the
+    /// desired spelling alphabet character mappings.
+    ///
+    /// # Arguments
+    ///
+    /// * `alphabet` - The [`SpellingAlphabet`] to use for character
+    ///   conversions.
+    ///
+    /// # Examples
+    ///
+    ///
+    /// ```
+    /// # use spellabet::{PhoneticConverter, SpellingAlphabet};
+    /// let converter = PhoneticConverter::new(&SpellingAlphabet::default());
+    /// ```
     #[must_use]
     pub fn new(alphabet: &SpellingAlphabet) -> Self {
         let conversion_map = alphabet.initialize();
@@ -34,28 +80,108 @@ impl PhoneticConverter {
         }
     }
 
+    /// Get the current character mappings of the `PhoneticConverter` instance.
     #[must_use]
     pub const fn mappings(&self) -> &HashMap<char, String> {
         &self.conversion_map
     }
 
+    /// Configures the current `PhoneticConverter` instance to either output
+    /// code words in "nonce form" or not, based on the given boolean value.
+    ///
+    /// Nonce form means each letter character is expanded into the form "'A' as
+    /// in ALFA". Digits and symbols are always returned using the normal output
+    /// format.
+    ///
+    /// # Arguments
+    ///
+    /// * `nonce_form` - If true, enables nonce form output. Otherwise, the
+    ///   normal output format is used.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spellabet::{PhoneticConverter, SpellingAlphabet};
+    /// let converter = PhoneticConverter::new(&SpellingAlphabet::default()).nonce_form(true);
+    /// println!("{}", converter.convert("Hello"));
+    /// ```
+    ///
+    /// ```text
+    /// 'H' as in HOTEL, 'e' as in echo, 'l' as in lima, 'l' as in lima, 'o' as in oscar
+    /// ```
     #[must_use]
     pub const fn nonce_form(mut self, nonce_form: bool) -> Self {
         self.nonce_form = nonce_form;
         self
     }
 
+    /// Modifies the conversion map of the current `PhoneticConverter` instance
+    /// by adding or replacing mappings based on the given overrides map.
+    ///
+    /// # Arguments
+    ///
+    /// * `overrides_map` - The desired character to code word mappings to
+    ///   override. The capitalization of the keys and values will be
+    ///   automatically normalized.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// # use spellabet::{PhoneticConverter, SpellingAlphabet};
+    ///
+    /// let mut converter = PhoneticConverter::new(&SpellingAlphabet::default());
+    ///
+    /// let mut overrides_map = HashMap::new();
+    /// overrides_map.insert('a', "Apple".to_string());
+    /// overrides_map.insert('b', "Banana".to_string());
+    ///
+    /// println!("BEFORE: {}", converter.convert("abcd"));
+    /// ```
+    ///
+    /// ```text
+    /// BEFORE: alfa bravo charlie delta
+    /// ```
+    ///
+    /// ```
+    /// # use std::collections::HashMap;
+    /// # use spellabet::{PhoneticConverter, SpellingAlphabet};
+    /// # let mut converter = PhoneticConverter::new(&SpellingAlphabet::default());
+    /// # let mut overrides_map = HashMap::new();
+    /// # overrides_map.insert('a', "Apple".to_string());
+    /// # overrides_map.insert('b', "Banana".to_string());
+    /// converter = converter.with_overrides(overrides_map);
+    /// println!("AFTER: {}", converter.convert("abcd"));
+    /// ```
+    ///
+    /// ```text
+    /// AFTER: apple banana charlie delta
+    /// ```
     #[must_use]
-    pub fn with_overrides(mut self, overrides: HashMap<char, String>) -> Self {
-        let lower_overrides: HashMap<char, String> = overrides
+    pub fn with_overrides(mut self, overrides_map: HashMap<char, String>) -> Self {
+        let normalized_overrides: HashMap<char, String> = overrides_map
             .into_iter()
             .map(|(k, v)| (k.to_ascii_lowercase(), v.to_case(Case::Pascal)))
             .collect();
 
-        self.conversion_map.extend(lower_overrides);
+        self.conversion_map.extend(normalized_overrides);
         self
     }
 
+    /// Converts the given text into a string of code words using the current
+    /// character mappings of the `PhoneticConverter` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - The text to convert into code words.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spellabet::{PhoneticConverter, SpellingAlphabet};
+    /// let converter = PhoneticConverter::new(&SpellingAlphabet::default());
+    /// assert_eq!(converter.convert("Hello"), "HOTEL echo lima lima oscar");
+    /// ```
     #[must_use]
     pub fn convert(&self, text: &str) -> String {
         let mut result = String::new();
@@ -77,12 +203,10 @@ impl PhoneticConverter {
     fn convert_char(&self, character: char, result: &mut String) {
         match self.conversion_map.get(&character.to_ascii_lowercase()) {
             Some(word) => {
-                let code_word = if character.is_lowercase() {
-                    word.to_lowercase()
-                } else if character.is_uppercase() {
-                    word.to_uppercase()
-                } else {
-                    word.clone()
+                let code_word = match character {
+                    _ if character.is_lowercase() => word.to_lowercase(),
+                    _ if character.is_uppercase() => word.to_uppercase(),
+                    _ => word.clone(),
                 };
 
                 if self.nonce_form && character.is_alphabetic() {
@@ -95,7 +219,8 @@ impl PhoneticConverter {
         }
     }
 
-    /// Dumps the current conversion map to the provided writer.
+    /// Writes the current character mappings of the `PhoneticConverter`
+    /// instance to the given writer.
     ///
     /// # Arguments
     ///
@@ -108,6 +233,27 @@ impl PhoneticConverter {
     /// This function will return an error if writing to the provided writer
     /// fails. The specific conditions under which this may occur depend on the
     /// nature of the writer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use spellabet::{PhoneticConverter, SpellingAlphabet};
+    /// let converter = PhoneticConverter::new(&SpellingAlphabet::default());
+    ///
+    /// let mut buf = Vec::new();
+    /// let verbose = false;
+    /// converter.dump_alphabet(&mut buf, verbose)?;
+    /// let output = String::from_utf8(buf)?;
+    /// println!("{output}");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ```text
+    /// a -> Alfa
+    /// b -> Bravo
+    /// c -> Charlie
+    /// ...
+    /// ```
     pub fn dump_alphabet(
         &self,
         mut writer: impl std::io::Write,
@@ -140,17 +286,16 @@ fn custom_char_ordering(a: char, b: char) -> Ordering {
 }
 
 impl SpellingAlphabet {
+    /// Generates and returns a character to code word map based on the current
+    /// `SpellingAlphabet`.
     #[must_use]
     pub fn initialize(&self) -> HashMap<char, String> {
         let mut map: HashMap<char, String> = HashMap::new();
 
         let extend_map = |map: &mut HashMap<char, String>, source_map: &[(char, &str)]| {
-            map.extend(
-                source_map
-                    .iter()
-                    .map(|(k, v)| (*k, (*v).to_string()))
-                    .collect::<HashMap<char, String>>(),
-            );
+            for (k, v) in source_map {
+                map.insert(*k, (*v).to_string());
+            }
         };
 
         extend_map(&mut map, &DEFAULT_DIGITS_AND_SYMBOLS);

--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -64,7 +64,7 @@ fn test_unknown_characters() {
 
 #[test]
 fn test_mappings() {
-    let converter = init_converter().nonce_form(false);
+    let converter = init_converter();
     let mappings = converter.mappings();
 
     // Check that mappings contain some expected entries
@@ -145,11 +145,11 @@ fn test_without_overrides() {
 #[test]
 fn test_with_overrides() {
     let mut converter = init_converter();
-    let mut overrides: HashMap<char, String> = HashMap::new();
-    overrides.insert('A', "Able".to_string());
-    overrides.insert('B', "Baker".to_string());
+    let mut overrides_map: HashMap<char, String> = HashMap::new();
+    overrides_map.insert('A', "Able".to_string());
+    overrides_map.insert('B', "Baker".to_string());
 
-    converter = converter.with_overrides(overrides);
+    converter = converter.with_overrides(overrides_map);
 
     // Check that overrides worked
     assert_snapshot!(converter.convert("a"), @"able");
@@ -166,10 +166,10 @@ fn test_with_overrides() {
 #[test]
 fn test_lowercase_key_in_overrides() {
     let mut converter = init_converter();
-    let mut overrides: HashMap<char, String> = HashMap::new();
-    overrides.insert('c', "Cain".to_string());
+    let mut overrides_map: HashMap<char, String> = HashMap::new();
+    overrides_map.insert('c', "Cain".to_string());
 
-    converter = converter.with_overrides(overrides);
+    converter = converter.with_overrides(overrides_map);
 
     // Check that overrides map key was normalized
     assert_snapshot!(converter.convert("c"), @"cain");
@@ -180,10 +180,10 @@ fn test_lowercase_key_in_overrides() {
 #[test]
 fn test_uppercase_key_in_overrides() {
     let mut converter = init_converter();
-    let mut overrides: HashMap<char, String> = HashMap::new();
-    overrides.insert('C', "Cain".to_string());
+    let mut overrides_map: HashMap<char, String> = HashMap::new();
+    overrides_map.insert('C', "Cain".to_string());
 
-    converter = converter.with_overrides(overrides);
+    converter = converter.with_overrides(overrides_map);
 
     // Check that overrides map key was normalized
     assert_snapshot!(converter.convert("c"), @"cain");
@@ -194,15 +194,15 @@ fn test_uppercase_key_in_overrides() {
 #[test]
 fn test_overrides_value_normalization() {
     let mut converter = init_converter();
-    let mut overrides: HashMap<char, String> = HashMap::new();
-    overrides.insert('-', "hyphen".to_string());
-    overrides.insert('/', "SLANT".to_string());
-    overrides.insert('(', "brackets on".to_string());
-    overrides.insert(')', "bracketsOff".to_string());
-    overrides.insert('!', "exclamation-mark".to_string());
-    overrides.insert('?', "question_mark".to_string());
+    let mut overrides_map: HashMap<char, String> = HashMap::new();
+    overrides_map.insert('-', "hyphen".to_string());
+    overrides_map.insert('/', "SLANT".to_string());
+    overrides_map.insert('(', "brackets on".to_string());
+    overrides_map.insert(')', "bracketsOff".to_string());
+    overrides_map.insert('!', "exclamation-mark".to_string());
+    overrides_map.insert('?', "question_mark".to_string());
 
-    converter = converter.with_overrides(overrides);
+    converter = converter.with_overrides(overrides_map);
 
     // Check that overrides map value was normalized
     assert_snapshot!(converter.convert("-"), @"Hyphen");

--- a/crates/spellout/Cargo.toml
+++ b/crates/spellout/Cargo.toml
@@ -10,6 +10,8 @@ readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
+keywords = ["cli", "command-line", "formatting", "humanize", "text"]
+categories = ["command-line-utilities", "text-processing", "value-formatting"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -71,8 +71,8 @@ fn main() -> Result<()> {
     let mut converter = PhoneticConverter::new(&alphabet).nonce_form(cli.nonce_form);
 
     if let Some(overrides_str) = cli.overrides {
-        let overrides = parse_overrides(&overrides_str).context("Failed to parse overrides")?;
-        converter = converter.with_overrides(overrides);
+        let overrides_map = parse_overrides(&overrides_str).context("Failed to parse overrides")?;
+        converter = converter.with_overrides(overrides_map);
     }
 
     if cli.dump_alphabet {
@@ -114,7 +114,7 @@ fn process_input(input: &str, converter: &PhoneticConverter, verbose: bool) {
 }
 
 fn parse_overrides(input: &str) -> Result<HashMap<char, String>> {
-    let mut overrides = HashMap::new();
+    let mut overrides_map = HashMap::new();
 
     for s in input.split(',') {
         let parts: Vec<&str> = s.split('=').collect();
@@ -135,10 +135,10 @@ fn parse_overrides(input: &str) -> Result<HashMap<char, String>> {
             anyhow::bail!("Empty value in override: {s}");
         }
 
-        overrides.insert(key, parts[1].to_string());
+        overrides_map.insert(key, parts[1].to_string());
     }
 
-    Ok(overrides)
+    Ok(overrides_map)
 }
 
 #[test]


### PR DESCRIPTION
I've decided to use doctests for now, even though they're slow. It's not too realistic of a problem, since I doubt there will be much need for the library outside of the `spellout` binary.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [x] Added tests covering any code changes
