### PR TITLE
Generate spellout package assets via build.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +120,16 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2e32b579dae093c2424a8b7e2bea09c89da01e1ce5065eb2f0a6f1cc15cc1f"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -296,6 +315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +354,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "is-terminal",
  "spellabet",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 homepage= "https://github.com/EarthmanMuons/spellout/"
 repository = "https://github.com/EarthmanMuons/spellout/"
 license = "MIT OR Apache-2.0"
+publish = false
 
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,

--- a/crates/spellout/Cargo.toml
+++ b/crates/spellout/Cargo.toml
@@ -20,3 +20,8 @@ anyhow = "1.0.71"
 clap = { version = "4.3.0", features = ["derive", "env", "wrap_help"] }
 is-terminal = "0.4.7"
 spellabet = { path = "../spellabet" }
+
+[build-dependencies]
+clap = { version = "4.3.0", default-features = false }
+clap_complete = "4.3.1"
+clap_mangen = "0.2.12"

--- a/crates/spellout/build.rs
+++ b/crates/spellout/build.rs
@@ -1,0 +1,60 @@
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+use clap::CommandFactory;
+use clap_complete::{generate_to, Shell};
+use clap_mangen::Man;
+use cli::Cli;
+
+#[path = "src/cli.rs"]
+mod cli;
+
+type DynError = Box<dyn std::error::Error>;
+
+fn main() -> Result<(), DynError> {
+    // Cargo sets the `OUT_DIR` environment variable to the folder in which all
+    // output and intermediate artifacts should be placed.
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(val) => PathBuf::from(val),
+        Err(e) => {
+            eprintln!("OUT_DIR environment variable not defined");
+            return Err(e.into());
+        }
+    };
+
+    generate_completions(&out_dir)?;
+    generate_man_page(&out_dir)?;
+
+    Ok(())
+}
+
+fn generate_completions<P: AsRef<Path>>(out_dir: P) -> Result<(), DynError> {
+    let completions_dir = out_dir.as_ref().join("completions");
+    fs::create_dir_all(&completions_dir)?;
+
+    let mut cmd = Cli::command();
+    for shell in [
+        Shell::Bash,
+        Shell::Elvish,
+        Shell::Fish,
+        Shell::PowerShell,
+        Shell::Zsh,
+    ] {
+        generate_to(shell, &mut cmd, "spellout", &completions_dir)?;
+    }
+
+    Ok(())
+}
+
+fn generate_man_page<P: AsRef<Path>>(out_dir: P) -> Result<(), DynError> {
+    let man_dir = out_dir.as_ref().join("man");
+    fs::create_dir_all(&man_dir)?;
+
+    let cmd = Cli::command();
+    let man = Man::new(cmd);
+    let mut buffer: Vec<u8> = Default::default();
+    man.render(&mut buffer)?;
+    fs::write(man_dir.join("spellout.1"), buffer)?;
+
+    Ok(())
+}

--- a/crates/spellout/src/cli.rs
+++ b/crates/spellout/src/cli.rs
@@ -1,0 +1,53 @@
+use clap::{Parser, ValueEnum};
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Which spelling alphabet to use for the conversion
+    #[arg(short, long, env = "SPELLOUT_ALPHABET")]
+    #[arg(value_enum, default_value_t = Alphabet::Nato)]
+    pub alphabet: Alphabet,
+
+    /// Define overrides for spelling alphabet code words
+    ///
+    /// Provide a comma-separated list of character=word pairs like
+    /// "a=apple,b=banana" which will override the default values.
+    #[arg(short, long, env = "SPELLOUT_OVERRIDES")]
+    pub overrides: Option<String>,
+
+    /// Display the spelling alphabet and exit
+    ///
+    /// Shows only letters by default; add the `--verbose` flag to also show
+    /// digits and symbols.
+    #[arg(long)]
+    pub dump_alphabet: bool,
+
+    /// Expand output into nonce form like "'A' as in ALFA"
+    #[arg(short, long, env = "SPELLOUT_NONCE_FORM")]
+    #[arg(value_parser = clap::builder::FalseyValueParser::new())]
+    pub nonce_form: bool,
+
+    /// Use verbose output
+    ///
+    /// Include the input characters along with each line's output.
+    #[arg(short, long, env = "SPELLOUT_VERBOSE")]
+    #[arg(value_parser = clap::builder::FalseyValueParser::new())]
+    pub verbose: bool,
+
+    /// An input character string to convert into code words
+    ///
+    /// If no input strings are provided, the program reads lines from standard
+    /// input.
+    #[arg(value_name = "STRING")]
+    pub input: Vec<String>,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum Alphabet {
+    /// Los Angeles Police Department (LAPD)
+    Lapd,
+    /// North Atlantic Treaty Organization (NATO)
+    Nato,
+    /// United States Financial Industry
+    UsFinancial,
+}

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -3,61 +3,13 @@ use std::io::{self, BufRead};
 
 use anyhow::{Context, Result};
 use clap::error::{ContextKind, ContextValue, ErrorKind};
-use clap::{CommandFactory, Parser, ValueEnum};
+use clap::{CommandFactory, Parser};
 use is_terminal::IsTerminal;
 use spellabet::{PhoneticConverter, SpellingAlphabet};
 
-#[derive(Parser)]
-#[command(author, version, about, long_about = None)]
-struct Cli {
-    /// Which spelling alphabet to use for the conversion
-    #[arg(short, long, env = "SPELLOUT_ALPHABET")]
-    #[arg(value_enum, default_value_t = Alphabet::Nato)]
-    alphabet: Alphabet,
+use crate::cli::{Alphabet, Cli};
 
-    /// Define overrides for spelling alphabet code words
-    ///
-    /// Provide a comma-separated list of character=word pairs like
-    /// "a=apple,b=banana" which will override the default values.
-    #[arg(short, long, env = "SPELLOUT_OVERRIDES")]
-    overrides: Option<String>,
-
-    /// Display the spelling alphabet and exit
-    ///
-    /// Shows only letters by default; add the `--verbose` flag to also show
-    /// digits and symbols.
-    #[arg(long)]
-    dump_alphabet: bool,
-
-    /// Expand output into nonce form like "'A' as in ALFA"
-    #[arg(short, long, env = "SPELLOUT_NONCE_FORM")]
-    #[arg(value_parser = clap::builder::FalseyValueParser::new())]
-    nonce_form: bool,
-
-    /// Use verbose output
-    ///
-    /// Include the input characters along with each line's output.
-    #[arg(short, long, env = "SPELLOUT_VERBOSE")]
-    #[arg(value_parser = clap::builder::FalseyValueParser::new())]
-    verbose: bool,
-
-    /// An input character string to convert into code words
-    ///
-    /// If no input strings are provided, the program reads lines from standard
-    /// input.
-    #[arg(value_name = "STRING")]
-    input: Vec<String>,
-}
-
-#[derive(Clone, Debug, ValueEnum)]
-enum Alphabet {
-    /// Los Angeles Police Department (LAPD)
-    Lapd,
-    /// North Atlantic Treaty Organization (NATO)
-    Nato,
-    /// United States Financial Industry
-    UsFinancial,
-}
+mod cli;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();


### PR DESCRIPTION
To allow for easy parsing of the derived Clap command using the built-in CommandFactory trait, I moved the `Cli` struct and `Alphabet` enum into a dedicated file. This allows us to keep our build dependencies to a minimum.

See:
- https://docs.rs/clap_complete/latest/clap_complete/
- https://docs.rs/clap_mangen/latest/clap_mangen/
- https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
