### PR TITLE
Copy build script outputs and important docs to dist directory via xtask

### DIFF
--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![warn(clippy::nursery, clippy::pedantic)]
+#![allow(clippy::question_mark)]
 
 use std::path::PathBuf;
 use std::{env, fs};
@@ -12,6 +13,7 @@ use crate::commands::cargo_cmd;
 use crate::utils::{copy_dir_to, project_root, verbose_cd};
 use crate::Config;
 
+// TODO: remove allow(clippy::question_mark)
 #[derive(Debug, DeJson)]
 struct CheckMessage {
     out_dir: Option<String>,

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -4,6 +4,34 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use xshell::Shell;
 
+/// Recursively copies a directory from `from` to `to`.
+pub fn copy_dir_to<P: AsRef<Path>>(from: P, to: P) -> Result<()> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+
+    if !from.is_dir() {
+        anyhow::bail!("source is not a directory: {}", from.display());
+    }
+
+    fs::create_dir_all(to)?;
+
+    for entry_result in fs::read_dir(from)? {
+        let entry = entry_result?;
+        let path = entry.path();
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("failed to get file name"))?;
+
+        if path.is_dir() {
+            copy_dir_to(&path, &to.join(file_name))?;
+        } else {
+            fs::copy(&path, &to.join(file_name))?;
+        }
+    }
+
+    Ok(())
+}
+
 pub fn find_files<P: AsRef<Path>>(dir: P, extension: &str) -> Result<Vec<PathBuf>> {
     let mut result = Vec::new();
     let dir_path = dir.as_ref();


### PR DESCRIPTION
The idea here is that we can easily put all of the asset files together to package a release for distribution. I may have to tweak things once we've got cross-compilation happening though. Here's what it looks like at the moment:

```
$ cargo xtask dist
    Finished dev [unoptimized] target(s) in 0.01s
     Running `target/debug/xtask dist`
$ cargo build --profile production --bin spellout
    Finished production [optimized] target(s) in 0.02s
Copying target/production/spellout to target/dist/spellout/spellout
Copying target/production/build/spellout-5d36dcb43376fd72/out/* to target/dist/spellout/
Copying CHANGELOG.md to target/dist/spellout/CHANGELOG.md
Copying LICENSE-APACHE to target/dist/spellout/LICENSE-APACHE
Copying LICENSE-MIT to target/dist/spellout/LICENSE-MIT
Copying README.md to target/dist/spellout/README.md

$ tree target/dist
target/dist/
└── spellout
    ├── completions
    │   ├── _spellout
    │   ├── _spellout.ps1
    │   ├── spellout.bash
    │   ├── spellout.elv
    │   └── spellout.fish
    ├── man
    │   └── spellout.1
    ├── CHANGELOG.md
    ├── LICENSE-APACHE
    ├── LICENSE-MIT
    ├── README.md
    └── spellout
```

Related to https://github.com/EarthmanMuons/spellout/pull/43

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
