### PR TITLE
Remove redundant acronym text

### DIFF
--- a/crates/spellout/src/cli.rs
+++ b/crates/spellout/src/cli.rs
@@ -51,9 +51,9 @@ pub struct Cli {
 
 #[derive(Clone, Debug, ValueEnum)]
 pub enum Alphabet {
-    /// Los Angeles Police Department (LAPD)
+    /// Los Angeles Police Department
     Lapd,
-    /// North Atlantic Treaty Organization (NATO)
+    /// North Atlantic Treaty Organization
     Nato,
     /// United States Financial Industry
     UsFinancial,


### PR DESCRIPTION
This was actually causing a bug in the Fish shell completion, because fish uses parentheses for subshells, so when you would try to tab-complete an alphabet, it was launching a subshell and trying to run the `LAPD` command, for example. That does not exist, so it would spit out an error and not complete as expected.

```
$ spellout -a <TAB>fish: Unknown command: LAPD
fish:
LAPD
^~~^
in command substitution
```

Since the option argument is itself already the acronym, we might as well remove the redundant version to fix the completion script.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
