### PR TITLE
Add current git hash to the version output

### DIFF
--- a/crates/spellout/build.rs
+++ b/crates/spellout/build.rs
@@ -1,0 +1,43 @@
+#![deny(clippy::all)]
+#![warn(clippy::nursery, clippy::pedantic)]
+
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let pkg_version = env::var("CARGO_PKG_VERSION").unwrap();
+
+    current_git_hash().map_or_else(
+        || {
+            println!("cargo:rustc-env=SPELLOUT_VERSION={pkg_version}");
+        },
+        |hash| {
+            println!("cargo:rustc-env=SPELLOUT_VERSION={pkg_version}+{hash}");
+        },
+    );
+}
+
+fn current_git_hash() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+
+    let hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    if hash.is_empty() {
+        return None;
+    }
+
+    let is_dirty = Command::new("git")
+        .args(["diff", "--quiet", "HEAD", "--"])
+        .status()
+        .map(|status| !status.success())
+        .unwrap_or(false);
+
+    if is_dirty {
+        Some(format!("{hash}.dirty"))
+    } else {
+        Some(hash)
+    }
+}

--- a/crates/spellout/src/cli.rs
+++ b/crates/spellout/src/cli.rs
@@ -1,7 +1,8 @@
 use clap::{Parser, ValueEnum};
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, about, long_about = None)]
+#[command(version = get_version())]
 pub struct Cli {
     /// Which spelling alphabet to use for the conversion
     #[arg(short, long, env = "SPELLOUT_ALPHABET")]
@@ -73,4 +74,8 @@ pub enum Asset {
     Powershell,
     /// Completions file for Z shell
     Zsh,
+}
+
+fn get_version() -> &'static str {
+    option_env!("SPELLOUT_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
 }

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::nursery, clippy::pedantic)]
+
 use std::collections::HashMap;
 use std::io::{self, BufRead};
 
@@ -59,7 +62,8 @@ fn main() -> Result<()> {
             err.exit();
         } else {
             // Data was provided to stdin
-            for line in io::stdin().lock().lines() {
+            let lines = io::stdin().lock().lines();
+            for line in lines {
                 let input = line.context("Failed to read line from stdin")?;
                 process_input(&input, &converter, cli.verbose);
             }
@@ -124,5 +128,5 @@ fn generate_man_page() -> Result<()> {
 
 #[test]
 fn verify_cli() {
-    Cli::command().debug_assert()
+    Cli::command().debug_assert();
 }

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::nursery, clippy::pedantic)]
-
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::{env, fs};


### PR DESCRIPTION
This build metadata can be useful to track down the exact commit used to compile the application. It will also check if the repository was dirty (has modifications) and append that information accordingly.

Using 12 characters to abbreviate the Git hash should be more than sufficient to be unambiguous, especially considering we're still using the current cargo package version as well.

See:
- https://semver.org/#spec-item-10
- https://blog.cuviper.com/2013/11/10/how-short-can-git-abbreviate/

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
