### PR TITLE
Clean up the xtask dist generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,6 @@ opt-level = 3
 opt-level = 3
 
 [profile.release]
-lto = "thin"
-
-[profile.production]
-inherits = "release"
 codegen-units = 1
 lto = true
 panic = "abort"

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -20,6 +20,7 @@ struct Package {
     #[allow(dead_code)]
     name: String,
     targets: Vec<Target>,
+    version: String,
 }
 
 #[derive(Debug, DeJson)]
@@ -36,8 +37,8 @@ pub fn dist(config: &Config) -> Result<()> {
     }
     let binaries = project_binaries(config)?;
 
-    for binary in &binaries {
-        let dest_dir = dist_dir().join(binary);
+    for (binary, version) in &binaries {
+        let dest_dir = dist_dir().join(format!("{binary}-{version}"));
         fs::create_dir_all(&dest_dir)?;
 
         build_binary(config, binary, &dest_dir)?;
@@ -139,7 +140,7 @@ fn generate_assets(config: &Config, binary: &str, dest_dir: &Path) -> Result<()>
     Ok(())
 }
 
-fn project_binaries(config: &Config) -> Result<Vec<String>> {
+fn project_binaries(config: &Config) -> Result<Vec<(String, String)>> {
     let sh = Shell::new()?;
     let mut binaries = Vec::new();
 
@@ -154,7 +155,7 @@ fn project_binaries(config: &Config) -> Result<Vec<String>> {
         for package in metadata.packages {
             for target in &package.targets {
                 if target.name != "xtask" && target.kind.contains(&"bin".to_string()) {
-                    binaries.push(target.name.clone());
+                    binaries.push((target.name.clone(), package.version.clone()));
                 }
             }
         }

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -52,7 +52,7 @@ fn build_binary(config: &Config, binary: &str, dest_dir: &Path) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
-        let args = vec!["build", "--profile", "production", "--bin", binary];
+        let args = vec!["build", "--release", "--bin", binary];
         cmd.args(args).run()?;
     }
 
@@ -61,7 +61,7 @@ fn build_binary(config: &Config, binary: &str, dest_dir: &Path) -> Result<()> {
     } else {
         binary.to_string()
     };
-    let src = production_dir().join(&binary_filename);
+    let src = release_dir().join(&binary_filename);
     let dest = dest_dir.join(&binary_filename);
 
     fs::copy(&src, &dest)?;
@@ -121,8 +121,7 @@ fn generate_assets(config: &Config, binary: &str, dest_dir: &Path) -> Result<()>
         if let Some(cmd) = cmd_option {
             let args = vec![
                 "run",
-                "--profile",
-                "production",
+                "--release",
                 "--bin",
                 binary,
                 "--",
@@ -167,8 +166,8 @@ fn dist_dir() -> PathBuf {
     target_dir().join("dist")
 }
 
-fn production_dir() -> PathBuf {
-    target_dir().join("production")
+fn release_dir() -> PathBuf {
+    target_dir().join("release")
 }
 
 fn target_dir() -> PathBuf {


### PR DESCRIPTION
No reason to invent something new that's not discoverable or intuitive to developers in the community. We can just have our highly-optimized settings on the normal release profile. The dist destination directory should also have the version number in there.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
