### PR TITLE
Explain why we fallback to CARGO_PKG_VERSION

### DIFF
--- a/crates/spellout/src/cli.rs
+++ b/crates/spellout/src/cli.rs
@@ -77,5 +77,6 @@ pub enum Asset {
 }
 
 fn get_version() -> &'static str {
+    // fallback if compiling from a source tarball without git
     option_env!("SPELLOUT_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
 }


### PR DESCRIPTION
Many packagers will prefer to grab a snapshot source tarball rather than use Git directly to clone a project's source code when packaging up a release for distribution. Since our build script uses Git to inject metadata into the environment, that won't work if we're in compiling from a source tarball and thus our custom version won't exist. In that case, we want to fallback to Cargo's default behavior. This already works, I just wanted to document it for posterity.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
