### PR TITLE
Configure workspace for cargo-release compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ checksum = "1dbabb1cbd15a1d6d12d9ed6b35cc6777d4af87ab3ba155ea37215f20beab80c"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "is_ci",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.64"
 description = "Convert characters into their equivalent spelling alphabet code words"
 documentation = "https://github.com/EarthmanMuons/spellout/"
 readme = "README.md"
-homepage= "https://github.com/EarthmanMuons/spellout/"
+homepage = "https://github.com/EarthmanMuons/spellout/"
 repository = "https://github.com/EarthmanMuons/spellout/"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -30,3 +30,10 @@ codegen-units = 1
 lto = true
 panic = "abort"
 strip = true
+
+# https://github.com/crate-ci/cargo-release/
+[workspace.metadata.release]
+publish = false
+push = false
+tag-message = "Release {{crate_name}} v{{version}}"
+verify = false

--- a/crates/spellabet/CHANGELOG.md
+++ b/crates/spellabet/CHANGELOG.md
@@ -14,5 +14,6 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 <!-- next-url -->
 
-[Unreleased]: https://github.com/EarthmanMuons/spellout/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/EarthmanMuons/spellout/commits/v0.1.0
+[Unreleased]:
+  https://github.com/EarthmanMuons/spellout/compare/spellabet-v0.1.0...HEAD
+[0.1.0]: https://github.com/EarthmanMuons/spellout/commits/spellabet-v0.1.0

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -1,19 +1,28 @@
 [package]
 name = "spellabet"
-version.workspace = true
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "My library description."
 documentation = "https://earthmanmuons.github.io/spellout/spellabet/index.html"
-readme.workspace = true
+readme = "README.md"
 homepage = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellabet"
 repository = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellabet"
 license.workspace = true
 keywords = ["formatting", "humanize", "text"]
 categories = ["text-processing", "value-formatting"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# https://github.com/crate-ci/cargo-release/
+[package.metadata.release]
+pre-release-replacements = [
+  { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+  { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+  { file = "CHANGELOG.md", search = "<!-- release-date -->", replace = "- {{date}}" },
+  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] <!-- release-date -->", exactly = 1 },
+  { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/EarthmanMuons/spellout/compare/{{tag_name}}...HEAD", exactly = 1 },
+  { file = "README.md", search = "spellabet = .*", replace = "{{crate_name}} = \"{{version}}\"" },
+]
 
 [dependencies]
 convert_case = "0.6.0"

--- a/crates/spellout/Cargo.toml
+++ b/crates/spellout/Cargo.toml
@@ -13,7 +13,16 @@ license.workspace = true
 keywords = ["cli", "command-line", "formatting", "humanize", "text"]
 categories = ["command-line-utilities", "text-processing", "value-formatting"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# https://github.com/crate-ci/cargo-release/
+[package.metadata.release]
+pre-release-replacements = [
+  { file = "../../CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+  { file = "../../CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+  { file = "../../CHANGELOG.md", search = "<!-- release-date -->", replace = "- {{date}}" },
+  { file = "../../CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] <!-- release-date -->", exactly = 1 },
+  { file = "../../CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/EarthmanMuons/spellout/compare/{{tag_name}}...HEAD", exactly = 1 },
+]
+tag-prefix = ""
 
 [dependencies]
 anyhow = "1.0.71"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "xtask"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 rust-version = "1.64"
 license = "MIT OR Apache-2.0"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# https://github.com/crate-ci/cargo-release/
+[package.metadata.release]
+release = false
 
 [dependencies]
 anyhow = "1.0.71"


### PR DESCRIPTION
Using cargo-release will help eliminate mistakes when preparing to cut a new release. It will still take a few steps, but we can write jobs to be triggered manually that will keep the process consistent with no need to run them locally.

I've made the xtask crate explicitly internal and it will be ignored by cargo-release. Since we're managing spellabc as a public library, it should maintain its own versioning and CHANGELOG.

See:
- https://github.com/crate-ci/cargo-release/
- https://matklad.github.io/2021/08/22/large-rust-workspaces.html#Smaller-Tips

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
