### PR TITLE
Have bump-version commit message and PR title match

### DIFF
--- a/.github/cue/bump-version.cue
+++ b/.github/cue/bump-version.cue
@@ -73,11 +73,11 @@ bumpVersion: {
 			},
 			// the changelog spacing will need a fixup
 			_#prettier & {
-				with: prettier_options: "--color --prose-wrap always --write"
+				with: prettier_options: "--color --prose-wrap always --write **/*.md"
 			},
 			_#createPullRequest & {with: {
 				"branch-suffix":  "short-commit-hash"
-				"commit-message": "Prepare next {{ inputs.level }} release of {{ inputs.package }}"
+				"commit-message": "[{{ inputs.package }}] Prepare next {{ inputs.level }} release"
 				title:            "[{{ inputs.package }}] Prepare next {{ inputs.level }} release"
 				body: """
 					This PR was auto-generated and ran the following commands:
@@ -87,7 +87,7 @@ bumpVersion: {
 					$ cargo install --locked cargo-release
 					$ cargo release version --execute --no-confirm --package "{{ inputs.package }}" "{{ inputs.level }}"
 					$ cargo release replace --execute --no-confirm --package "{{ inputs.package }}"
-					$ prettier --prose-wrap always --write
+					$ prettier --prose-wrap always --write **/*.md
 					```
 
 					Please review the submitted changes. After merging, the rebased commit will automatically be tagged and a draft release will be opened.

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -58,13 +58,13 @@ jobs:
         uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1
         with:
           prettier_version: 2.8.8
-          prettier_options: --color --prose-wrap always --write
+          prettier_options: --color --prose-wrap always --write **/*.md
       - id: cpr
         name: Create pull request
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
           branch-suffix: short-commit-hash
-          commit-message: Prepare next {{ inputs.level }} release of {{ inputs.package }}
+          commit-message: '[{{ inputs.package }}] Prepare next {{ inputs.level }} release'
           title: '[{{ inputs.package }}] Prepare next {{ inputs.level }} release'
           body: |-
             This PR was auto-generated and ran the following commands:
@@ -74,7 +74,7 @@ jobs:
             $ cargo install --locked cargo-release
             $ cargo release version --execute --no-confirm --package "{{ inputs.package }}" "{{ inputs.level }}"
             $ cargo release replace --execute --no-confirm --package "{{ inputs.package }}"
-            $ prettier --prose-wrap always --write
+            $ prettier --prose-wrap always --write **/*.md
             ```
 
             Please review the submitted changes. After merging, the rebased commit will automatically be tagged and a draft release will be opened.


### PR DESCRIPTION
Having the `[package]` prefix does make it nicer for filtering, even though we don't do that for all commits. Also, there is a GitHub bug and the workflow didn't show up, so I'm hoping a change to the file will get things rolling.

See:
- https://github.com/orgs/community/discussions/25219

EDIT: Actually, it looks like GitHub is [having some general PR issues](https://www.githubstatus.com/) at the moment:

![image](https://github.com/EarthmanMuons/spellout/assets/4742/876988fe-d549-4ee6-bceb-caef7e755d46)

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
