### PR TITLE
Fix up the bump-version workflow issues

### DIFF
--- a/.github/cue/bump-version.cue
+++ b/.github/cue/bump-version.cue
@@ -38,64 +38,74 @@ bumpVersion: {
 		RUSTFLAGS:         "-D warnings"
 	}
 
-	jobs: prepareRelease: {
-		name: "prepare release"
-		permissions: {
-			contents:        "write"
-			"pull-requests": "write"
-		}
+	jobs: prepareNextRelease: {
+		name:      "prepare next release"
 		"runs-on": defaultRunner
 		steps: [
-			_#checkoutCode & {with: ref: defaultBranch},
+			_#generateToken,
+			_#checkoutCode & {with: {
+				ref:   defaultBranch
+				token: "${{ steps.generate_token.outputs.token }}"
+			}},
 			_#installRust,
 			_#cacheRust,
+			_#installTool & {with: tool: "cargo-release"},
 			{
-				name: "Update cargo dependencies for package {{ inputs.package }}"
+				name: "Update cargo dependencies for package ${{ inputs.package }}"
 				run: """
-					cargo update --package "{{ inputs.package }}"
+					cargo update --package "${{ inputs.package }}"
 					"""
 			},
 			{
-				name: "Install cargo-release"
-				run:  "cargo install --locked cargo-release"
-			},
-			{
-				name: "Bump {{ inputs.package }} crate version"
+				name: "Bump ${{ inputs.level }} version for package ${{ inputs.package }}"
 				run: """
-					cargo release version --execute --no-confirm --package "{{ inputs.package }}" "{{ inputs.level }}"
+					cargo release version -v --execute --no-confirm --package "${{ inputs.package }}" "${{ inputs.level }}"
 					"""
 			},
 			{
 				name: "Perform pre-release replacements"
 				run: """
-					cargo release replace --execute --no-confirm --package "{{ inputs.package }}"
+					cargo release replace -v --execute --no-confirm --package "${{ inputs.package }}"
 					"""
 			},
-			// the changelog spacing will need a fixup
-			_#prettier & {
-				with: prettier_options: "--color --prose-wrap always --write **/*.md"
+			{
+				name: "Fix up Markdown formatting"
+				run:  "npx --yes prettier@\(_prettierVersion) --color --prose-wrap always --write -- **/*.md"
 			},
-			_#createPullRequest & {with: {
-				"branch-suffix":  "short-commit-hash"
-				"commit-message": "[{{ inputs.package }}] Prepare next {{ inputs.level }} release"
-				title:            "[{{ inputs.package }}] Prepare next {{ inputs.level }} release"
-				body: """
-					This PR was auto-generated and ran the following commands:
-
-					```
-					$ cargo update --package "{{ inputs.package }}"
-					$ cargo install --locked cargo-release
-					$ cargo release version --execute --no-confirm --package "{{ inputs.package }}" "{{ inputs.level }}"
-					$ cargo release replace --execute --no-confirm --package "{{ inputs.package }}"
-					$ prettier --prose-wrap always --write **/*.md
-					```
-
-					Please review the submitted changes. After merging, the rebased commit will automatically be tagged and a draft release will be opened.
+			{
+				name: "Get the new release version"
+				run: """
+					version=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name == "${{ inputs.package }}") | .version')
+					echo "release_version=${version}" >> "$GITHUB_ENV"
 					"""
-			}},
+			},
+			_#createPullRequest & {
+				with: {
+					token:            "${{ steps.generate_token.outputs.token }}"
+					"branch-suffix":  "timestamp"
+					"commit-message": "Prepare ${{ inputs.package }} v${{ env.release_version }} ${{ inputs.level }} release"
+					title:            "Prepare ${{ inputs.package }} v${{ env.release_version }} ${{ inputs.level }} release"
+					body:             """
+						This PR was automatically created by the [bump-version](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow, which ran the following commands:
+
+
+						```
+						$ cargo update --package ${{ inputs.package }}
+						$ cargo release version --execute --package ${{ inputs.package }} ${{ inputs.level }}
+						$ cargo release replace --execute --package ${{ inputs.package }}
+						$ prettier --prose-wrap always --write -- **/*.md
+						```
+
+						**Please review the submitted changes.**
+						
+						Once this PR is merged into the _\(defaultBranch)_ branch, an automated process will tag the rebased commit.
+						"""
+				}},
 			{
 				name: "Annotate workflow run with PR URL"
-				run:  "echo \"### Opened Pull Request: {{ steps.cpr.outputs.pull-request-url }}\" >> \"$GITHUB_STEP_SUMMARY\""
+				run: """
+					echo "#### :shipit: Opened pull request for ${{ inputs.package }} v${{ env.release_version }}: ${{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"
+					"""
 			},
 		]
 	}

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -64,6 +64,17 @@ _#filterChanges: _#step & {
 	uses: "dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50"
 }
 
+// https://github.com/tibdex/github-app-token/releases
+_#generateToken: _#step & {
+	id:   "generate_token"
+	name: "Generate a GitHub App token"
+	uses: "tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92"
+	with: {
+		app_id:      "${{ secrets.APP_ID }}"
+		private_key: "${{ secrets.APP_PRIVATE_KEY }}"
+	}
+}
+
 // https://github.com/cue-lang/setup-cue/commits/main
 _#installCue: _#step & {
 	name: "Install CUE \(with.version)"
@@ -104,10 +115,11 @@ _#pathsFilter: _#step & {
 }
 
 // https://github.com/creyD/prettier_action/releases
-_#prettier: _#step & {
+_prettierVersion: "2.8.8"
+_#prettier:       _#step & {
 	name: "Check formatting"
 	uses: "creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1"
-	with: prettier_version: "2.8.8"
+	with: prettier_version: _prettierVersion
 }
 
 _setupMsrv: [

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -26,17 +26,21 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
 jobs:
-  prepareRelease:
-    name: prepare release
-    permissions:
-      contents: write
-      pull-requests: write
+  prepareNextRelease:
+    name: prepare next release
     runs-on: ubuntu-latest
     steps:
+      - id: generate_token
+        name: Generate a GitHub App token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           ref: main
+          token: ${{ steps.generate_token.outputs.token }}
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
@@ -46,37 +50,43 @@ jobs:
         with:
           shared-key: stable-ubuntu-latest
         timeout-minutes: 5
-      - name: Update cargo dependencies for package {{ inputs.package }}
-        run: cargo update --package "{{ inputs.package }}"
       - name: Install cargo-release
-        run: cargo install --locked cargo-release
-      - name: Bump {{ inputs.package }} crate version
-        run: cargo release version --execute --no-confirm --package "{{ inputs.package }}" "{{ inputs.level }}"
-      - name: Perform pre-release replacements
-        run: cargo release replace --execute --no-confirm --package "{{ inputs.package }}"
-      - name: Check formatting
-        uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1
+        uses: taiki-e/install-action@835cdc15ee7680334982c900847bcafb86487299
         with:
-          prettier_version: 2.8.8
-          prettier_options: --color --prose-wrap always --write **/*.md
+          tool: cargo-release
+      - name: Update cargo dependencies for package ${{ inputs.package }}
+        run: cargo update --package "${{ inputs.package }}"
+      - name: Bump ${{ inputs.level }} version for package ${{ inputs.package }}
+        run: cargo release version -v --execute --no-confirm --package "${{ inputs.package }}" "${{ inputs.level }}"
+      - name: Perform pre-release replacements
+        run: cargo release replace -v --execute --no-confirm --package "${{ inputs.package }}"
+      - name: Fix up Markdown formatting
+        run: npx --yes prettier@2.8.8 --color --prose-wrap always --write -- **/*.md
+      - name: Get the new release version
+        run: |-
+          version=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name == "${{ inputs.package }}") | .version')
+          echo "release_version=${version}" >> "$GITHUB_ENV"
       - id: cpr
         name: Create pull request
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
-          branch-suffix: short-commit-hash
-          commit-message: '[{{ inputs.package }}] Prepare next {{ inputs.level }} release'
-          title: '[{{ inputs.package }}] Prepare next {{ inputs.level }} release'
+          token: ${{ steps.generate_token.outputs.token }}
+          branch-suffix: timestamp
+          commit-message: Prepare ${{ inputs.package }} v${{ env.release_version }} ${{ inputs.level }} release
+          title: Prepare ${{ inputs.package }} v${{ env.release_version }} ${{ inputs.level }} release
           body: |-
-            This PR was auto-generated and ran the following commands:
+            This PR was automatically created by the [bump-version](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow, which ran the following commands:
+
 
             ```
-            $ cargo update --package "{{ inputs.package }}"
-            $ cargo install --locked cargo-release
-            $ cargo release version --execute --no-confirm --package "{{ inputs.package }}" "{{ inputs.level }}"
-            $ cargo release replace --execute --no-confirm --package "{{ inputs.package }}"
-            $ prettier --prose-wrap always --write **/*.md
+            $ cargo update --package ${{ inputs.package }}
+            $ cargo release version --execute --package ${{ inputs.package }} ${{ inputs.level }}
+            $ cargo release replace --execute --package ${{ inputs.package }}
+            $ prettier --prose-wrap always --write -- **/*.md
             ```
 
-            Please review the submitted changes. After merging, the rebased commit will automatically be tagged and a draft release will be opened.
+            **Please review the submitted changes.**
+
+            Once this PR is merged into the _main_ branch, an automated process will tag the rebased commit.
       - name: Annotate workflow run with PR URL
-        run: 'echo "### Opened Pull Request: {{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"'
+        run: 'echo "#### :shipit: Opened pull request for ${{ inputs.package }} v${{ env.release_version }}: ${{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"'


### PR DESCRIPTION
One thing I didn't expect, is that GitHub purposefully will not trigger jobs if you use another workflow's default GITHUB_TOKEN to create that PR in an automated way. They do this to prevent accidental infinite loops, and to get around it using a dedicated GitHup App is what they recommend.

See:
- https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
- https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
