### PR TITLE
Allow for initial release of spellabet v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased] <!-- release-date -->
 
+### Added
+
+- Initial release.
+
 <!-- next-url -->
 
 [Unreleased]: https://github.com/EarthmanMuons/spellout/compare/v0.1.0...HEAD

--- a/README.md
+++ b/README.md
@@ -1,25 +1,22 @@
-# spellout &emsp; [![CI Status]][actions]
+# spellout
 
-[CI Status]:
-  https://img.shields.io/github/actions/workflow/status/EarthmanMuons/spellout/rust.yml?event=merge_group&label=CI&logo=github
-[actions]:
-  https://github.com/EarthmanMuons/spellout/actions?query=event%3Amerge_group
+**Convert characters into spelling alphabet code words.**
 
-**Convert characters into their equivalent spelling alphabet code words.**
+[![CI status](https://img.shields.io/github/actions/workflow/status/EarthmanMuons/spellout/rust.yml?event=merge_group&label=ci&logo=github)](https://github.com/EarthmanMuons/spellout/actions?query=event%3Amerge_group)
 
 ---
 
-spellout is a command-line application for transforming text strings into their
-equivalent code words based on predefined [spelling alphabets][]. These spelling
-alphabets, such as the NATO phonetic alphabet, are designed to boost verbal
-clarity, particluarly when spelling out words over low-fidelity voice channels.
-The application supports multiple standard alphabets and allows for
-customization to suit specific communication needs.
+A command-line application for transforming text strings into corresponding code
+words based on predefined [spelling alphabets][], like the NATO phonetic
+alphabet. These alphabets are designed to enhance verbal clarity, especially
+when spelling out words over low-fidelity voice channels. This library supports
+several standard alphabets and allows for customization to suit specific
+communication needs.
 
-In its operation, spellout will maintain the original capitalization of letters
-by returning either lowercase or uppercase code words. Known digits and other
-symbols undergo the same conversion process into code words. Unrecognized
-characters are returned as is, without conversion.
+In operation, spellout preserves the original capitalization of letters by
+returning either lowercase or uppercase code words. It similarly converts known
+digits and other symbols into code words, while unrecognized characters are
+returned unconverted.
 
 [spelling alphabets]: https://en.wikipedia.org/wiki/Spelling_alphabet
 
@@ -139,7 +136,11 @@ module written by [James FitzGibbon][@jf647].
 spellout is distributed under the terms of both the Apache License (Version 2.0)
 and the MIT License.
 
-See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
+See [LICENSE-APACHE][] and [LICENSE-MIT][] for details.
+
+[LICENSE-APACHE]:
+  https://github.com/EarthmanMuons/spellout/blob/main/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/EarthmanMuons/spellout/blob/main/LICENSE-MIT
 
 ## Contribution
 
@@ -147,5 +148,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-If you would like to contribute to the project, please read our
-[guide for contributors](CONTRIBUTING.md).
+If you would like to contribute to the project, please read our [guide for
+contributors][CONTRIBUTING.md].
+
+[CONTRIBUTING.md]:
+  https://github.com/EarthmanMuons/spellout/blob/main/CONTRIBUTING.md

--- a/crates/spellabet/CHANGELOG.md
+++ b/crates/spellabet/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased] <!-- release-date -->
 
+### Added
+
+- Initial release; published to https://crates.io/.
+
 <!-- next-url -->
 
 [Unreleased]:

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-description = "My library description."
+description = "Convert characters into spelling alphabet code words"
 documentation = "https://earthmanmuons.github.io/spellout/spellabet/index.html"
 readme = "README.md"
 homepage = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellabet"
@@ -24,6 +24,7 @@ pre-release-replacements = [
   { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/EarthmanMuons/spellout/compare/{{tag_name}}...HEAD", exactly = 1 },
   { file = "README.md", search = "spellabet = .*", replace = "{{crate_name}} = \"{{version}}\"" },
 ]
+tag = true
 
 [dependencies]
 convert_case = "0.6.0"

--- a/crates/spellabet/README.md
+++ b/crates/spellabet/README.md
@@ -1,24 +1,23 @@
-# spellabet &emsp; [![MSRV]][rust-version]
+# spellabet
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.64-blue
-[rust-version]:
-  https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
+**Convert characters into spelling alphabet code words.**
 
-**Convert characters into their equivalent spelling alphabet code words.**
+[![CI status](https://img.shields.io/github/actions/workflow/status/EarthmanMuons/spellout/rust.yml?event=merge_group&label=ci&logo=github)](https://github.com/EarthmanMuons/spellout/actions?query=event%3Amerge_group)
+[![crates.io](https://img.shields.io/crates/v/spellabet)](https://crates.io/crates/spellabet/)
+[![MSRV](https://img.shields.io/badge/rust-1.64%2B-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 
 ---
 
-spellabet is a Rust library for transforming text strings into their equivalent
-code words based on predefined [spelling alphabets][]. These spelling alphabets,
-such as the NATO phonetic alphabet, are designed to boost verbal clarity,
-particluarly when spelling out words over low-fidelity voice channels. The
-library supports multiple standard alphabets and allows for customization to
-suit specific communication needs.
+A Rust library for transforming text strings into corresponding code words based
+on predefined [spelling alphabets][], like the NATO phonetic alphabet. These
+alphabets are designed to enhance verbal clarity, especially when spelling out
+words over low-fidelity voice channels. This library supports several standard
+alphabets and allows for customization to suit specific communication needs.
 
-In its operation, spellabet will maintain the original capitalization of letters
-by returning either lowercase or uppercase code words. Known digits and other
-symbols undergo the same conversion process into code words. Unrecognized
-characters are returned as is, without conversion.
+In operation, spellabet preserves the original capitalization of letters by
+returning either lowercase or uppercase code words. It similarly converts known
+digits and other symbols into code words, while unrecognized characters are
+returned unconverted.
 
 [spelling alphabets]: https://en.wikipedia.org/wiki/Spelling_alphabet
 
@@ -58,10 +57,37 @@ Detailed examples and generated API reference documentation can be found at
 - MSRV increases are considered regular changes, not breaking changes, in terms
   of Semantic Versioning.
 
+## Credits
+
+spellabet was inspired by the output from the no-longer-in-existence [WinGuides
+Secure Password Generator][WinGuides] that disappeared back in January 2007, and
+the similarly inspired [Lingua::Alphabet::Phonetic::Password][Lingua] Perl
+module written by [James FitzGibbon][@jf647].
+
+[WinGuides]:
+  https://web.archive.org/web/20070106073206/www.winguides.com/security/password.php
+[Lingua]: https://github.com/jf647/Lingua-Alphabet-Phonetic-Password/
+[@jf647]: https://github.com/jf647/
+
 ## License
 
 spellabet is distributed under the terms of both the Apache License (Version
 2.0) and the MIT License.
 
-See [LICENSE-APACHE](../../LICENSE-APACHE) and [LICENSE-MIT](../../LICENSE-MIT)
-for details.
+See [LICENSE-APACHE][] and [LICENSE-MIT][] for details.
+
+[LICENSE-APACHE]:
+  https://github.com/EarthmanMuons/spellout/blob/main/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/EarthmanMuons/spellout/blob/main/LICENSE-MIT
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+If you would like to contribute to the project, please read our [guide for
+contributors][CONTRIBUTING.md].
+
+[CONTRIBUTING.md]:
+  https://github.com/EarthmanMuons/spellout/blob/main/CONTRIBUTING.md

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -3,17 +3,24 @@
 
 //! # Spelling Alphabet
 //!
-//! A library for converting text string characters into their equivalent
-//! [spelling alphabet](https://en.wikipedia.org/wiki/Spelling_alphabet) code words.
+//! A Rust library for transforming text strings into corresponding code words
+//! based on predefined [spelling alphabets][], like the NATO phonetic alphabet.
+//! These alphabets are designed to enhance verbal clarity, especially when
+//! spelling out words over low-fidelity voice channels. This library supports
+//! several standard alphabets and allows for customization to suit specific
+//! communication needs.
+//!
+//! In operation, spellabet preserves the original capitalization of letters by
+//! returning either lowercase or uppercase code words. It similarly converts
+//! known digits and other symbols into code words, while unrecognized
+//! characters are returned unconverted.
 //!
 //! This library powers the command line utility `spellout`, which provides a
-//! handy interface for phonetic conversions. Check out
-//! [`spellout` on GitHub](https://github.com/EarthmanMuons/spellout/) for more information.
+//! handy interface for phonetic conversions. Check out [`spellout` on GitHub][]
+//! for more information.
 //!
-//! In its operation, spellabet will maintain the original capitalization of
-//! letters by returning either lowercase or uppercase code words. Known digits
-//! and other symbols undergo the same conversion process into code words.
-//! Unrecognized characters are returned as is, without conversion.
+//! [spelling alphabets]: https://en.wikipedia.org/wiki/Spelling_alphabet
+//! [`spellout` on GitHub]: https://github.com/EarthmanMuons/spellout/
 //!
 //! # Example
 //!


### PR DESCRIPTION
This should get published automatically to https://crates.io/. 🤞 

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [x] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
