### PR TITLE
Set a committer identity for auto-tag job

### DIFF
--- a/.github/cue/auto-tag-releases.cue
+++ b/.github/cue/auto-tag-releases.cue
@@ -20,9 +20,16 @@ autoTagReleases: {
 	jobs: tagUntagged: {
 		name:      "tag untagged package releases"
 		"runs-on": defaultRunner
+		env: {
+			GIT_COMMITTER_EMAIL: "noreply@github.com"
+			GIT_COMMITTER_NAME:  "GitHub"
+		}
 		steps: [
 			_#generateToken,
-			_#checkoutCode & {with: ref: defaultBranch},
+			_#checkoutCode & {with: {
+				ref:   defaultBranch
+				token: "${{ steps.generate_token.outputs.token }}"
+			}},
 			_#installRust,
 			_#cacheRust,
 			_#installTool & {with: tool: "cargo-release"},
@@ -32,8 +39,7 @@ autoTagReleases: {
 			},
 			{
 				name: "Push any new tags"
-				env: GITHUB_TOKEN: "${{ steps.generate_token.outputs.token }}"
-				run: "cargo release push -v --execute --no-confirm"
+				run:  "cargo release push -v --execute --no-confirm"
 			},
 		]
 	}

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -15,6 +15,9 @@ jobs:
   tagUntagged:
     name: tag untagged package releases
     runs-on: ubuntu-latest
+    env:
+      GIT_COMMITTER_EMAIL: noreply@github.com
+      GIT_COMMITTER_NAME: GitHub
     steps:
       - id: generate_token
         name: Generate a GitHub App token
@@ -26,6 +29,7 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           ref: main
+          token: ${{ steps.generate_token.outputs.token }}
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
@@ -42,6 +46,4 @@ jobs:
       - name: Add any missing tags
         run: cargo release tag -v --execute --no-confirm
       - name: Push any new tags
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: cargo release push -v --execute --no-confirm

--- a/crates/spellabet/README.md
+++ b/crates/spellabet/README.md
@@ -45,8 +45,9 @@ ECHO x-ray alfa mike papa lima echo One Two Tree Exclamation
 
 ## Documentation
 
-Detailed examples and generated API reference documentation can be found at
-<https://earthmanmuons.github.io/spellout/spellabet/index.html>
+For detailed examples of using this library, along with the latest generated API
+reference documentation, please visit
+<https://earthmanmuons.github.io/spellout/spellabet/index.html>.
 
 ## Minimum Supported Rust Version (MSRV) Policy
 


### PR DESCRIPTION
I've also tweaked how the token is used in the environment. I believe the auth is cached as part of the checkout step, so subsequent steps that use `git` functionality should inherit those permissions. I don't think setting the `GITHUB_TOKEN` environment variable when pushing the tags would actually do anything since `cargo-release` has no awareness over that mechanism.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
