### PR TITLE
Allow pushing of tags by cargo-release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,5 @@ strip = true
 # https://github.com/crate-ci/cargo-release/
 [workspace.metadata.release]
 allow-branch = ["main"]
-push = false
 tag = false
 tag-message = "Release {{crate_name}} v{{version}}"


### PR DESCRIPTION
I had put this config into place originally to stop commits and push attempts, but commits only happen when using the full `cargo release` workflow, and we're using individual subcommands to control things. No need to worry about local users accidentally doing this either, as the main branch is protected.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
