### PR TITLE
Allow the tagged GITHUB_REF when publishing to crates.io

### DIFF
--- a/.github/cue/auto-tag-releases.cue
+++ b/.github/cue/auto-tag-releases.cue
@@ -18,7 +18,7 @@ autoTagReleases: {
 	}
 
 	jobs: tagUntagged: {
-		name:      "tag untagged package releases"
+		name:      "tag untagged"
 		"runs-on": defaultRunner
 		env: {
 			GIT_COMMITTER_EMAIL: "noreply@github.com"

--- a/.github/cue/publish-crate.cue
+++ b/.github/cue/publish-crate.cue
@@ -16,7 +16,7 @@ publishCrate: {
 	}
 
 	jobs: publishUnpublished: {
-		name:      "publish unpublished crate releases"
+		name:      "publish unpublished"
 		"runs-on": defaultRunner
 		steps: [
 			_#checkoutCode,
@@ -26,7 +26,9 @@ publishCrate: {
 			{
 				name: "Publish any unpublished crates to crates.io"
 				env: CARGO_REGISTY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
-				run: "cargo release publish -v --execute --no-confirm"
+				run: """
+					cargo release publish -v --execute --no-confirm --allow-branch="$GITHUB_REF"
+					"""
 			},
 		]
 	}

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -13,7 +13,7 @@ env:
   RUSTFLAGS: -D warnings
 jobs:
   tagUntagged:
-    name: tag untagged package releases
+    name: tag untagged
     runs-on: ubuntu-latest
     env:
       GIT_COMMITTER_EMAIL: noreply@github.com

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -13,7 +13,7 @@ env:
   RUSTFLAGS: -D warnings
 jobs:
   publishUnpublished:
-    name: publish unpublished crate releases
+    name: publish unpublished
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -34,4 +34,4 @@ jobs:
       - name: Publish any unpublished crates to crates.io
         env:
           CARGO_REGISTY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo release publish -v --execute --no-confirm
+        run: cargo release publish -v --execute --no-confirm --allow-branch="$GITHUB_REF"


### PR DESCRIPTION
These tags all exist on the main branch, as desired, but when we trigger a job from the tag creation, we end up in a detached HEAD state. As long as we're on the tag that we're publishing, that is okay and we can override things to allow generating the package and publishing it to crates.io.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
