### PR TITLE
Allow publishing from detached HEAD state

### DIFF
--- a/.github/cue/publish-crate.cue
+++ b/.github/cue/publish-crate.cue
@@ -3,10 +3,7 @@ package workflows
 publishCrate: {
 	name: "publish-crate"
 
-	on: push: tags: [
-		"*-v[0-9]+.[0-9]+.[0-9]+",
-		"v[0-9]+.[0-9]+.[0-9]+",
-	]
+	on: push: tags: [ "*-v[0-9]+.[0-9]+.[0-9]+"]
 
 	env: {
 		CARGO_INCREMENTAL: 0
@@ -27,7 +24,7 @@ publishCrate: {
 				name: "Publish any unpublished crates to crates.io"
 				env: CARGO_REGISTY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 				run: """
-					cargo release publish -v --execute --no-confirm --allow-branch="$GITHUB_REF"
+					cargo release publish -v --execute --no-confirm --allow-branch="HEAD"
 					"""
 			},
 		]

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -5,7 +5,6 @@ name: publish-crate
   push:
     tags:
       - '*-v[0-9]+.[0-9]+.[0-9]+'
-      - v[0-9]+.[0-9]+.[0-9]+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
@@ -34,4 +33,4 @@ jobs:
       - name: Publish any unpublished crates to crates.io
         env:
           CARGO_REGISTY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo release publish -v --execute --no-confirm --allow-branch="$GITHUB_REF"
+        run: cargo release publish -v --execute --no-confirm --allow-branch="HEAD"


### PR DESCRIPTION
I thought it would be fine referencing the $GITHUB_REF since that's what we're actually checking out, but  cargo-release picks up "HEAD" instead. This is the error it spits out:

> error: cannot release from branch "HEAD", instead switch to "refs/tags/spellabet-v0.1.0"

Related to https://github.com/EarthmanMuons/spellout/pull/77

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
