### PR TITLE
Checkout entire repo history before tagging

### DIFF
--- a/.github/cue/auto-tag-releases.cue
+++ b/.github/cue/auto-tag-releases.cue
@@ -27,8 +27,9 @@ autoTagReleases: {
 		steps: [
 			_#generateToken,
 			_#checkoutCode & {with: {
-				ref:   defaultBranch
-				token: "${{ steps.generate_token.outputs.token }}"
+				ref:           defaultBranch
+				token:         "${{ steps.generate_token.outputs.token }}"
+				"fetch-depth": 0
 			}},
 			_#installRust,
 			_#cacheRust,

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           ref: main
           token: ${{ steps.generate_token.outputs.token }}
+          fetch-depth: 0
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:


### PR DESCRIPTION
If we just have a depth of one commit, that's too shallow to know if the tags we're adding already exist within the repository, so we need the full history.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
