### PR TITLE
Use GITHUB_ENV to pass tag lists instead of GITHUB_OUTPUT

### DIFF
--- a/.github/cue/auto-tag-releases.cue
+++ b/.github/cue/auto-tag-releases.cue
@@ -35,10 +35,14 @@ autoTagReleases: {
 			_#cacheRust,
 			_#installTool & {with: tool: "cargo-release"},
 			{
-				id:   "before"
 				name: "Capture tags before"
 				run: """
-					echo "tags=$(git tag --list)" >> "$GITHUB_OUTPUT"
+					EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+					{
+					  echo "TAGS_BEFORE<<$EOF"
+					  git tag --list
+					  echo "EOF"
+					} >>"$GITHUB_ENV"
 					"""
 			},
 			{
@@ -50,17 +54,21 @@ autoTagReleases: {
 				run:  "cargo release push -v --execute --no-confirm"
 			},
 			{
-				id:   "after"
 				name: "Capture tags after"
 				run: """
-					echo "tags=$(git tag --list)" >> "$GITHUB_OUTPUT"
+					EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+					{
+					  echo "TAGS_AFTER<<$EOF"
+					  git tag --list
+					  echo "EOF"
+					} >>"$GITHUB_ENV"
 					"""
 			},
 			{
 				name: "Annotate workflow run with new tags"
 				run: """
 					echo "#### :sparkles: New tags:" >> "$GITHUB_STEP_SUMMARY";
-					comm -3 <(echo "${{ steps.before.outputs.tags }}") <(echo "${{ steps.after.outputs.tags }}") | sed -e 's/^[[:space:]]*//' -e 's/^/- /' >> "$GITHUB_STEP_SUMMARY";
+					comm -3 <(echo "${{ env.TAGS_BEFORE }}") <(echo "${{ env.TAGS_AFTER }}") | sed -e 's/^[[:space:]]*//' -e 's/^/- /' >> "$GITHUB_STEP_SUMMARY";
 					"""
 			},
 		]

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -44,17 +44,27 @@ jobs:
         uses: taiki-e/install-action@835cdc15ee7680334982c900847bcafb86487299
         with:
           tool: cargo-release
-      - id: before
-        name: Capture tags before
-        run: echo "tags=$(git tag --list)" >> "$GITHUB_OUTPUT"
+      - name: Capture tags before
+        run: |-
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          {
+            echo "TAGS_BEFORE<<$EOF"
+            git tag --list
+            echo "EOF"
+          } >>"$GITHUB_ENV"
       - name: Add any missing tags
         run: cargo release tag -v --execute --no-confirm
       - name: Push any new tags
         run: cargo release push -v --execute --no-confirm
-      - id: after
-        name: Capture tags after
-        run: echo "tags=$(git tag --list)" >> "$GITHUB_OUTPUT"
+      - name: Capture tags after
+        run: |-
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          {
+            echo "TAGS_AFTER<<$EOF"
+            git tag --list
+            echo "EOF"
+          } >>"$GITHUB_ENV"
       - name: Annotate workflow run with new tags
         run: |-
           echo "#### :sparkles: New tags:" >> "$GITHUB_STEP_SUMMARY";
-          comm -3 <(echo "${{ steps.before.outputs.tags }}") <(echo "${{ steps.after.outputs.tags }}") | sed -e 's/^[[:space:]]*//' -e 's/^/- /' >> "$GITHUB_STEP_SUMMARY";
+          comm -3 <(echo "${{ env.TAGS_BEFORE }}") <(echo "${{ env.TAGS_AFTER }}") | sed -e 's/^[[:space:]]*//' -e 's/^/- /' >> "$GITHUB_STEP_SUMMARY";


### PR DESCRIPTION
This simplifies things a bit if we're just passing data between steps withing the same job. Note that we also need to account for multiline strings, or we'll get an invalid format error when there's more than one tag on the repo.

See:
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
- https://www.shellcheck.net/wiki/SC2129

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
