### PR TITLE
Fix the nested target dir when copying dist artifacts

### DIFF
--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -215,8 +215,10 @@ fn dist_dir() -> PathBuf {
 
 fn release_dir() -> PathBuf {
     // Our setup for cross-compilation will set this environment variable in CI
-    let release_dir = env::var("CARGO_BUILD_TARGET").unwrap_or_else(|_| "release".to_string());
-    target_dir().join(release_dir)
+    env::var_os("CARGO_BUILD_TARGET").map_or_else(
+        || target_dir().join("release"),
+        |build_target| target_dir().join(build_target).join("release"),
+    )
 }
 
 fn target_dir() -> PathBuf {


### PR DESCRIPTION
I didn't realize that when you specify a target, it just adds that as an intermediate directory, rather than replace the profile name completely.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
