### PR TITLE
Refactor create_archive function to include target triple

### DIFF
--- a/.github/cue/draft-release.cue
+++ b/.github/cue/draft-release.cue
@@ -72,8 +72,8 @@ draftRelease: {
 					name: "Uploading release assets"
 					if:   "matrix.os != 'windows-latest'"
 					run: """
-						ls package/dist/
-						echo "Uploading 'spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.tar.gz' to: ${{ needs.create_release.outputs.upload_url }}"
+						ls target/dist/
+						echo "Uploading spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.tar.gz to: ${{ needs.create_release.outputs.upload_url }}"
 						"""
 				},
 			]

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -63,5 +63,5 @@ jobs:
       - name: Uploading release assets
         if: matrix.os != 'windows-latest'
         run: |-
-          ls package/dist/
-          echo "Uploading 'spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.tar.gz' to: ${{ needs.create_release.outputs.upload_url }}"
+          ls target/dist/
+          echo "Uploading spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.tar.gz to: ${{ needs.create_release.outputs.upload_url }}"


### PR DESCRIPTION
If it's available in the environment, we can add the target triple to the archive's filename.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
