### PR TITLE
Use gh cli application to upload release artifacts

### DIFF
--- a/.github/cue/draft-release.cue
+++ b/.github/cue/draft-release.cue
@@ -71,9 +71,12 @@ draftRelease: {
 				{
 					name: "Uploading release assets"
 					if:   "matrix.os != 'windows-latest'"
+					env: GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 					run: """
-						ls target/dist/
-						echo "Uploading spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.tar.gz to: ${{ needs.create_release.outputs.upload_url }}"
+						filename="spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.tar.gz"
+						echo "Uploading ${filename} to: ${{ needs.create_release.outputs.upload_url }}"
+						gh release upload "$GITHUB_REF_NAME" "target/dist/${filename}"
+						echo "- Uploaded release asset ${filename}" >>"$GITHUB_STEP_SUMMARY"
 						"""
 				},
 			]

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -62,6 +62,10 @@ jobs:
         run: cargo xtask dist
       - name: Uploading release assets
         if: matrix.os != 'windows-latest'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |-
-          ls target/dist/
-          echo "Uploading spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.tar.gz to: ${{ needs.create_release.outputs.upload_url }}"
+          filename="spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.tar.gz"
+          echo "Uploading ${filename} to: ${{ needs.create_release.outputs.upload_url }}"
+          gh release upload "$GITHUB_REF_NAME" "target/dist/${filename}"
+          echo "- Uploaded release asset ${filename}" >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
See:
- https://cli.github.com/manual/gh_release_upload
- https://cli.github.com/manual/gh_auth_login
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
