### PR TITLE
Force xtask wrapper to use stable toolchain

### DIFF
--- a/.github/cue/draft-release.cue
+++ b/.github/cue/draft-release.cue
@@ -69,15 +69,17 @@ draftRelease: {
 						CARGO:              "cross"
 						CARGO_BUILD_TARGET: "${{ matrix.target }}"
 					}
-					run: "cargo xtask dist"
+					run: "rustup run stable cargo xtask dist"
 				},
 				{
 					name: "Uploading release assets"
 					run: """
 						[[ "${{ matrix.os }}" == "windows-latest" ]] && extension="zip" || extension="tar.gz" 
 						filename="spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.${extension}"
+
 						echo "Uploading ${filename} to: ${{ needs.create_release.outputs.upload_url }}"
 						gh release upload "$GITHUB_REF_NAME" "target/dist/${filename}"
+
 						echo "- Uploaded release asset ${filename}" >>"$GITHUB_STEP_SUMMARY"
 						"""
 				},

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -80,6 +80,6 @@ jobs:
         env:
           CARGO: cross
           CARGO_BUILD_TARGET: ${{ matrix.target }}
-        run: cargo xtask dist
+        run: rustup run stable cargo xtask dist
       - name: Uploading release assets
-        run: "[[ \"${{ matrix.os }}\" == \"windows-latest\" ]] && extension=\"zip\" || extension=\"tar.gz\" \nfilename=\"spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.${extension}\"\necho \"Uploading ${filename} to: ${{ needs.create_release.outputs.upload_url }}\"\ngh release upload \"$GITHUB_REF_NAME\" \"target/dist/${filename}\"\necho \"- Uploaded release asset ${filename}\" >>\"$GITHUB_STEP_SUMMARY\""
+        run: "[[ \"${{ matrix.os }}\" == \"windows-latest\" ]] && extension=\"zip\" || extension=\"tar.gz\" \nfilename=\"spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.${extension}\"\n\necho \"Uploading ${filename} to: ${{ needs.create_release.outputs.upload_url }}\"\ngh release upload \"$GITHUB_REF_NAME\" \"target/dist/${filename}\"\n\necho \"- Uploaded release asset ${filename}\" >>\"$GITHUB_STEP_SUMMARY\""


### PR DESCRIPTION
Since we're cross-compiling via the wrapper script, we need it to ignore the `CARGO_BUILD_TARGET` environment variable. Otherwise it will also get cross-compiled and then it can't run.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
