### PR TITLE
Do not rely on implicit use of cross

### DIFF
--- a/.github/cue/draft-release.cue
+++ b/.github/cue/draft-release.cue
@@ -44,12 +44,12 @@ draftRelease: {
 			strategy: {
 				"fail-fast": false
 				matrix: include: [
-					{target: "aarch64-apple-darwin", os:       "macos-latest"},
-					{target: "aarch64-pc-windows-msvc", os:    "windows-latest"},
-					{target: "aarch64-unknown-linux-musl", os: "ubuntu-latest"},
-					{target: "x86_64-apple-darwin", os:        "macos-latest"},
-					{target: "x86_64-pc-windows-msvc", os:     "windows-latest"},
-					{target: "x86_64-unknown-linux-musl", os:  "ubuntu-latest"},
+					{target: "aarch64-apple-darwin", os:       "macos-latest", build_tool:   "cargo"},
+					{target: "aarch64-pc-windows-msvc", os:    "windows-latest", build_tool: "cargo"},
+					{target: "aarch64-unknown-linux-musl", os: "ubuntu-latest", build_tool:  "cross"},
+					{target: "x86_64-apple-darwin", os:        "macos-latest", build_tool:   "cargo"},
+					{target: "x86_64-pc-windows-msvc", os:     "windows-latest", build_tool: "cargo"},
+					{target: "x86_64-unknown-linux-musl", os:  "ubuntu-latest", build_tool:  "cargo"},
 				]}
 			"runs-on": "${{ matrix.os }}"
 			env: GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -66,10 +66,11 @@ draftRelease: {
 				{
 					name: "Building release assets"
 					run: """
-						if [[ "$OSTYPE" == "linux"* ]]; then
-						  export CARGO="cross"
+						if [[ "${{ matrix.build_tool }}" == "cross" ]]; then
+							cargo xtask dist --target "${{ matrix.target }}" --cross
+						else
+							cargo xtask dist --target "${{ matrix.target }}"
 						fi
-						cargo xtask dist --target "${{ matrix.target }}"
 						"""
 				},
 				{

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -43,16 +43,22 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             os: macos-latest
+            build_tool: cargo
           - target: aarch64-pc-windows-msvc
             os: windows-latest
+            build_tool: cargo
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
+            build_tool: cross
           - target: x86_64-apple-darwin
             os: macos-latest
+            build_tool: cargo
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            build_tool: cargo
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            build_tool: cargo
     runs-on: ${{ matrix.os }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,9 +84,10 @@ jobs:
           tool: cross
       - name: Building release assets
         run: |-
-          if [[ "$OSTYPE" == "linux"* ]]; then
-            export CARGO="cross"
+          if [[ "${{ matrix.build_tool }}" == "cross" ]]; then
+          	cargo xtask dist --target "${{ matrix.target }}" --cross
+          else
+          	cargo xtask dist --target "${{ matrix.target }}"
           fi
-          cargo xtask dist --target "${{ matrix.target }}"
       - name: Uploading release assets
         run: "if [[ \"${{ matrix.os }}\" == \"windows-latest\" ]]; then\n  extension=\"zip\"\nelse\n  extension=\"tar.gz\" \nfi\nfilename=\"spellout-${GITHUB_REF_NAME:1}-${{ matrix.target }}.${extension}\"\n\necho \"Uploading ${filename} to: ${{ needs.create_release.outputs.upload_url }}\"\ngh release upload \"$GITHUB_REF_NAME\" \"target/dist/${filename}\"\n\necho \":arrow_up: Uploaded release asset ${filename}\" >>\"$GITHUB_STEP_SUMMARY\""

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -22,6 +22,10 @@ pub fn cargo_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
     )
 }
 
+pub fn cross_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
+    create_cmd("cross", "https://github.com/cross-rs/cross", config, sh)
+}
+
 pub fn cue_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
     create_cmd("cue", "https://cuelang.org/", config, sh)
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,6 +19,7 @@ USAGE:
     cargo xtask [OPTIONS] [TASK]...
 
 OPTIONS:
+    --cross                Uses cross for cross-compilation instead of cargo
     -i, --ignore-missing   Ignores any missing tools; only warns during fixup
     --target <TRIPLE>      Sets the target triple that dist will build
     -h, --help             Prints help information
@@ -54,6 +55,7 @@ enum Task {
 }
 
 pub struct Config {
+    cross: bool,
     run_tasks: Vec<Task>,
     ignore_missing_commands: bool,
     target: Option<String>,
@@ -91,9 +93,10 @@ fn parse_args() -> Result<Config> {
     use lexopt::prelude::*;
 
     // default config values
-    let mut run_tasks = Vec::new();
+    let mut cross = false;
     let mut ignore_missing_commands = false;
     let mut target: Option<String> = None;
+    let mut run_tasks = Vec::new();
 
     let mut parser = lexopt::Parser::from_env();
     while let Some(arg) = parser.next()? {
@@ -102,10 +105,13 @@ fn parse_args() -> Result<Config> {
                 print!("{HELP}");
                 std::process::exit(0);
             }
+            Long("cross") => {
+                cross = true;
+            }
             Short('i') | Long("ignore-missing") => {
                 ignore_missing_commands = true;
             }
-            Short('t') | Long("target") => {
+            Long("target") => {
                 target = Some(parser.value()?.string()?);
             }
             Value(value) => {
@@ -138,6 +144,7 @@ fn parse_args() -> Result<Config> {
     }
 
     Ok(Config {
+        cross,
         run_tasks,
         ignore_missing_commands,
         target,


### PR DESCRIPTION
Trying to conditionally set the CARGO environment variable is too complex due to the xtask wrapper and the environment within an xshell Shell, so instead we'll just add an explicit option flag to select the command. I believe it's only necessary for Linux when not targetting the native host triple.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
