### PR TITLE
Ignore no packages selected error when adding tags

### DIFF
--- a/.github/cue/auto-tag-releases.cue
+++ b/.github/cue/auto-tag-releases.cue
@@ -47,7 +47,7 @@ autoTagReleases: {
 			},
 			{
 				name: "Add any missing tags"
-				run:  "cargo release tag -v --execute --no-confirm"
+				run:  "cargo release tag -v --execute --no-confirm || true"
 			},
 			{
 				name: "Push any new tags"

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -53,7 +53,7 @@ jobs:
             echo "$EOF"
           } >>"$GITHUB_ENV"
       - name: Add any missing tags
-        run: cargo release tag -v --execute --no-confirm
+        run: cargo release tag -v --execute --no-confirm || true
       - name: Push any new tags
         run: cargo release push -v --execute --no-confirm
       - name: Capture tags after


### PR DESCRIPTION
My impression from upstream was that it would exit cleanly if there were no new tags (after it skipped all existing tags), but apparently not. It should be okay to go ahead and always exit with success here, as the remaining steps will be a no-op.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
