### PR TITLE
Fix formatting for automated version bumps across docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased] <!-- release-date -->
 
+### Fixed
+
+- Fix formatting for automated version bumps across docs.
+
+## [0.1.0] - 2023-06-10
+
 ### Added
 
 - Initial release.

--- a/crates/spellabet/CHANGELOG.md
+++ b/crates/spellabet/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 - Rely on docs.rs for versioned library documentation.
 
+### Fixed
+
+- Fix formatting for automated version bumps across docs.
+
+## [0.1.0] - 2023-06-08
+
 ### Added
 
 - Initial release; published to https://crates.io/.

--- a/crates/spellabet/CHANGELOG.md
+++ b/crates/spellabet/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased] <!-- release-date -->
 
+### Changed
+
+- Rely on docs.rs for versioned library documentation.
+
 ### Added
 
 - Initial release; published to https://crates.io/.

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -17,13 +17,13 @@ publish = true
 # https://github.com/crate-ci/cargo-release/
 [package.metadata.release]
 pre-release-replacements = [
-  { file = "Cargo.toml", search = "docs.rs/spellabet/.*/", replace = "docs.rs/spellabet/{{version}}/" },
+  { file = "Cargo.toml", search = "docs.rs/spellabet/[0-9]+.[0-9]+.[0-9]+", replace = "docs.rs/spellabet/{{version}}", exactly = 1 },
   { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
   { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
   { file = "CHANGELOG.md", search = "<!-- release-date -->", replace = "- {{date}}" },
   { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] <!-- release-date -->", exactly = 1 },
   { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/EarthmanMuons/spellout/compare/{{tag_name}}...HEAD", exactly = 1 },
-  { file = "README.md", search = "docs.rs/spellabet/.*/", replace = "docs.rs/spellabet/{{version}}/" },
+  { file = "README.md", search = "docs.rs/spellabet/[0-9]+.[0-9]+.[0-9]+", replace = "docs.rs/spellabet/{{version}}" },
   { file = "README.md", search = "spellabet = .*", replace = "{{crate_name}} = \"{{version}}\"" },
 ]
 tag = true

--- a/crates/spellabet/Cargo.toml
+++ b/crates/spellabet/Cargo.toml
@@ -5,7 +5,7 @@ authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Convert characters into spelling alphabet code words"
-documentation = "https://earthmanmuons.github.io/spellout/spellabet/index.html"
+documentation = "https://docs.rs/spellabet/0.1.0/spellabet/"
 readme = "README.md"
 homepage = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellabet"
 repository = "https://github.com/EarthmanMuons/spellout/tree/main/crates/spellabet"
@@ -17,11 +17,13 @@ publish = true
 # https://github.com/crate-ci/cargo-release/
 [package.metadata.release]
 pre-release-replacements = [
+  { file = "Cargo.toml", search = "docs.rs/spellabet/.*/", replace = "docs.rs/spellabet/{{version}}/" },
   { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
   { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
   { file = "CHANGELOG.md", search = "<!-- release-date -->", replace = "- {{date}}" },
   { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] <!-- release-date -->", exactly = 1 },
   { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/EarthmanMuons/spellout/compare/{{tag_name}}...HEAD", exactly = 1 },
+  { file = "README.md", search = "docs.rs/spellabet/.*/", replace = "docs.rs/spellabet/{{version}}/" },
   { file = "README.md", search = "spellabet = .*", replace = "{{crate_name}} = \"{{version}}\"" },
 ]
 tag = true

--- a/crates/spellabet/README.md
+++ b/crates/spellabet/README.md
@@ -4,6 +4,7 @@
 
 [![CI status](https://img.shields.io/github/actions/workflow/status/EarthmanMuons/spellout/rust.yml?event=merge_group&label=ci&logo=github)](https://github.com/EarthmanMuons/spellout/actions?query=event%3Amerge_group)
 [![crates.io](https://img.shields.io/crates/v/spellabet)](https://crates.io/crates/spellabet/)
+[![docs.rs](https://img.shields.io/docsrs/spellabet)](https://docs.rs/spellabet/0.1.0/spellabet/)
 [![MSRV](https://img.shields.io/badge/rust-1.64%2B-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 
 ---

--- a/crates/spellabet/README.md
+++ b/crates/spellabet/README.md
@@ -20,7 +20,12 @@ returning either lowercase or uppercase code words. It similarly converts known
 digits and other symbols into code words, while unrecognized characters are
 returned unconverted.
 
+This library powers the command line utility `spellout`, which provides a handy
+interface for phonetic conversions. Check out [spellout on GitHub][] for more
+information.
+
 [spelling alphabets]: https://en.wikipedia.org/wiki/Spelling_alphabet
+[spellout on GitHub]: https://github.com/EarthmanMuons/spellout/
 
 ## Usage
 

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -16,11 +16,11 @@
 //! characters are returned unconverted.
 //!
 //! This library powers the command line utility `spellout`, which provides a
-//! handy interface for phonetic conversions. Check out [`spellout` on GitHub][]
+//! handy interface for phonetic conversions. Check out [spellout on GitHub][]
 //! for more information.
 //!
 //! [spelling alphabets]: https://en.wikipedia.org/wiki/Spelling_alphabet
-//! [`spellout` on GitHub]: https://github.com/EarthmanMuons/spellout/
+//! [spellout on GitHub]: https://github.com/EarthmanMuons/spellout/
 //!
 //! # Example
 //!


### PR DESCRIPTION
Since this was the initial release and I wasn't using our bump-version workflow, I missed that we didn't have things linked up properly in the CHANGELOG files. Now that the library has been pushed, docs.rs also built/tested our library, so we can use it for our documentation link. The advantage it has is that it will maintain prior versions, where our github-pages will always reflect the latest state of the repository.

I tested version bumps and replacements locally, but reverted them and will use the dedicated CI workflows to cut a new `spellabet` release.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [x] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
