### PR TITLE
Fix broken link when creating PR for version bump

### DIFF
--- a/.github/cue/bump-version.cue
+++ b/.github/cue/bump-version.cue
@@ -101,7 +101,8 @@ bumpVersion: {
 			{
 				name: "Annotate workflow run with PR URL"
 				run: """
-					echo "### :shipit: Opened pull request for ${{ inputs.package }} v${{ env.release_version }}: #${{ steps.cpr.outputs.pull-request-number }}" >> "$GITHUB_STEP_SUMMARY"
+					echo "### :shipit: Opened pull request for ${{ inputs.package }} v${{ env.release_version }}:" >> "$GITHUB_STEP_SUMMARY"
+					echo "- ${{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"
 					"""
 			},
 		]

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -88,4 +88,6 @@ jobs:
 
             Once this PR is merged into the _main_ branch, an automated process will tag the rebased commit.
       - name: Annotate workflow run with PR URL
-        run: 'echo "### :shipit: Opened pull request for ${{ inputs.package }} v${{ env.release_version }}: #${{ steps.cpr.outputs.pull-request-number }}" >> "$GITHUB_STEP_SUMMARY"'
+        run: |-
+          echo "### :shipit: Opened pull request for ${{ inputs.package }} v${{ env.release_version }}:" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ${{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
I had changed this to just the number because the line was long, but it didn't auto-link even with the displayed output matching what we want. I'll just use two lines to more closely match other annotations.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
