### PR TITLE
Check out full Git history when bumping versions

### DIFF
--- a/.github/cue/bump-version.cue
+++ b/.github/cue/bump-version.cue
@@ -43,7 +43,10 @@ bumpVersion: {
 		"runs-on": defaultRunner
 		steps: [
 			_#generateToken,
-			_#checkoutCode & {with: ref: defaultBranch},
+			_#checkoutCode & {with: {
+				ref:           defaultBranch
+				"fetch-depth": 0
+			}},
 			_#installRust,
 			_#cacheRust,
 			_#installTool & {with: tool: "cargo-release"},

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           ref: main
+          fetch-depth: 0
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:


### PR DESCRIPTION
By default, some of the smarts for cargo release subcommands relies on being able to look at previous tags, so we want to get the entire history. We did this already for tagging releases, but not when doing version bumps.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
