### PR TITLE
Dependabot bumps

### DIFF
--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -102,14 +102,14 @@ _#installRust: _#step & {
 // https://github.com/taiki-e/install-action/releases
 _#installTool: _#step & {
 	name: "Install \(with.tool)"
-	uses: "taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca"
+	uses: "taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c"
 	with: tool: string
 }
 
 // https://github.com/actions/labeler/releases
 _#labeler: _#step & {
 	name: "Label pull request based on paths of changed files"
-	uses: "actions/labeler@9fcb2c2f5584144ca754f8bfe8c6f81e77753375"
+	uses: "actions/labeler@0967ca812e7fdc8f5f71402a1b486d5bd061fe20"
 	with: dot: true
 }
 

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -41,7 +41,7 @@ jobs:
           shared-key: stable-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-release
-        uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+        uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         with:
           tool: cargo-release
       - name: Capture tags before

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -51,7 +51,7 @@ jobs:
           shared-key: stable-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-release
-        uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+        uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         with:
           tool: cargo-release
       - name: Update cargo dependencies for package ${{ inputs.package }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           shared-key: stable-ubuntu-latest
         timeout-minutes: 5
-      - uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+      - uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         if: matrix.os == 'ubuntu-latest'
         name: Install cross
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label pull request based on paths of changed files
-        uses: actions/labeler@9fcb2c2f5584144ca754f8bfe8c6f81e77753375
+        uses: actions/labeler@0967ca812e7fdc8f5f71402a1b486d5bd061fe20
         with:
           dot: true

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -85,7 +85,7 @@ jobs:
           shared-key: stable-${{ matrix.os }}
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+        uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         with:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors
@@ -120,7 +120,7 @@ jobs:
           shared-key: msrv-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+        uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         with:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -29,7 +29,7 @@ jobs:
           shared-key: stable-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-release
-        uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+        uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         with:
           tool: cargo-release
       - name: Publish crate to crates.io

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
           shared-key: stable-${{ matrix.os }}
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+        uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         with:
           tool: cargo-nextest
       - name: Compile tests
@@ -154,7 +154,7 @@ jobs:
           shared-key: msrv-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+        uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         with:
           tool: cargo-nextest
       - name: Compile tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set override to beta Rust
         run: rustup override set beta
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@9a865a852d3c02524dd81a4e49b8d524407b81ca
+        uses: taiki-e/install-action@d3712f40a2bae95e3ce25a24f82a795ed3df0f1c
         with:
           tool: cargo-nextest
       - name: Compile tests


### PR DESCRIPTION
- Bump actions/labeler from 4.1.0 to 4.2.0
- Bump taiki-e/install-action from 2.12.2 to 2.12.6

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
