### PR TITLE
Add a few historical spelling alphabet options

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,6 @@
 [default]
 locale = "en-us"
+
+[default.extend-words]
+# Don't correct the instrument "Oboe" code word.
+oboe = "oboe"

--- a/crates/spellabet/CHANGELOG.md
+++ b/crates/spellabet/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased] <!-- release-date -->
 
+### Added
+
+- Add the Joint Army/Navy spelling alphabet.
+- Add the Royal Navy spelling alphabet.
+- Add the Western Union spelling alphabet.
+
 ## [0.1.1] - 2023-06-10
 
 ### Changed

--- a/crates/spellabet/src/code_words.rs
+++ b/crates/spellabet/src/code_words.rs
@@ -44,6 +44,36 @@ pub const DEFAULT_DIGITS_AND_SYMBOLS: [(char, &str); 43] = [
     ('~', "Tilde"),
 ];
 
+// Joint Army/Navy (JAN)
+pub const JAN_ALPHABET: [(char, &str); 26] = [
+    ('a', "Able"),
+    ('b', "Baker"),
+    ('c', "Charlie"),
+    ('d', "Dog"),
+    ('e', "Easy"),
+    ('f', "Fox"),
+    ('g', "George"),
+    ('h', "How"),
+    ('i', "Item"),
+    ('j', "Jig"),
+    ('k', "King"),
+    ('l', "Love"),
+    ('m', "Mike"),
+    ('n', "Nan"),
+    ('o', "Oboe"),
+    ('p', "Peter"),
+    ('q', "Queen"),
+    ('r', "Roger"),
+    ('s', "Sugar"),
+    ('t', "Tare"),
+    ('u', "Uncle"),
+    ('v', "Victor"),
+    ('w', "William"),
+    ('x', "X-ray"),
+    ('y', "Yoke"),
+    ('z', "Zebra"),
+];
+
 // Los Angeles Police Department (LAPD)
 // Association of Public-Safety Communications Officials-International (APCO)
 pub const LAPD_ALPHABET: [(char, &str); 27] = [
@@ -112,6 +142,36 @@ pub const NATO_ALPHABET: [(char, &str); 30] = [
     ('9', "Niner"),
 ];
 
+// Royal Navy
+pub const ROYAL_NAVY_ALPHABET: [(char, &str); 26] = [
+    ('a', "Apples"),
+    ('b', "Butter"),
+    ('c', "Charlie"),
+    ('d', "Duff"),
+    ('e', "Edward"),
+    ('f', "Freddy"),
+    ('g', "George"),
+    ('h', "Harry"),
+    ('i', "Ink"),
+    ('j', "Johnnie"),
+    ('k', "King"),
+    ('l', "London"),
+    ('m', "Monkey"),
+    ('n', "Nuts"),
+    ('o', "Orange"),
+    ('p', "Pudding"),
+    ('q', "Queenie"),
+    ('r', "Robert"),
+    ('s', "Sugar"),
+    ('t', "Tommy"),
+    ('u', "Uncle"),
+    ('v', "Vinegar"),
+    ('w', "William"),
+    ('x', "Xerxes"),
+    ('y', "Yellow"),
+    ('z', "Zebra"),
+];
+
 // United States Financial Industry
 pub const US_FINANCIAL_ALPHABET: [(char, &str); 26] = [
     ('a', "Adam"),
@@ -140,4 +200,34 @@ pub const US_FINANCIAL_ALPHABET: [(char, &str); 26] = [
     ('x', "Xavier"),
     ('y', "Yogi"),
     ('z', "Zachary"),
+];
+
+// Western Union
+pub const WESTERN_UNION_ALPHABET: [(char, &str); 26] = [
+    ('a', "Adams"),
+    ('b', "Boston"),
+    ('c', "Chicago"),
+    ('d', "Denver"),
+    ('e', "Easy"),
+    ('f', "Frank"),
+    ('g', "George"),
+    ('h', "Henry"),
+    ('i', "Ida"),
+    ('j', "John"),
+    ('k', "King"),
+    ('l', "Lincoln"),
+    ('m', "Mary"),
+    ('n', "NewYork"),
+    ('o', "Ocean"),
+    ('p', "Peter"),
+    ('q', "Queen"),
+    ('r', "Roger"),
+    ('s', "Sugar"),
+    ('t', "Thomas"),
+    ('u', "Union"),
+    ('v', "Victor"),
+    ('w', "William"),
+    ('x', "X-ray"),
+    ('y', "Young"),
+    ('z', "Zero"),
 ];

--- a/crates/spellabet/src/lib.rs
+++ b/crates/spellabet/src/lib.rs
@@ -39,7 +39,10 @@ use std::char;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-use code_words::{DEFAULT_DIGITS_AND_SYMBOLS, LAPD_ALPHABET, NATO_ALPHABET, US_FINANCIAL_ALPHABET};
+use code_words::{
+    DEFAULT_DIGITS_AND_SYMBOLS, JAN_ALPHABET, LAPD_ALPHABET, NATO_ALPHABET, ROYAL_NAVY_ALPHABET,
+    US_FINANCIAL_ALPHABET, WESTERN_UNION_ALPHABET,
+};
 use convert_case::{Case, Casing};
 
 mod code_words;
@@ -55,14 +58,20 @@ pub struct PhoneticConverter {
 /// A spelling alphabet.
 #[derive(Default)]
 pub enum SpellingAlphabet {
+    /// The JAN (Joint Army/Navy) spelling alphabet.
+    Jan,
     /// The LAPD (Los Angeles Police Department) spelling alphabet.
     Lapd,
     /// The NATO (North Atlantic Treaty Organization) spelling alphabet.
     /// This is the default.
     #[default]
     Nato,
+    /// The Royal Navy spelling alphabet.
+    RoyalNavy,
     /// The United States Financial Industry spelling alphabet.
     UsFinancial,
+    /// The Western Union spelling alphabet.
+    WesternUnion,
 }
 
 impl PhoneticConverter {
@@ -312,9 +321,12 @@ impl SpellingAlphabet {
         extend_map(&mut map, &DEFAULT_DIGITS_AND_SYMBOLS);
 
         match self {
+            Self::Jan => extend_map(&mut map, &JAN_ALPHABET),
             Self::Lapd => extend_map(&mut map, &LAPD_ALPHABET),
             Self::Nato => extend_map(&mut map, &NATO_ALPHABET),
+            Self::RoyalNavy => extend_map(&mut map, &ROYAL_NAVY_ALPHABET),
             Self::UsFinancial => extend_map(&mut map, &US_FINANCIAL_ALPHABET),
+            Self::WesternUnion => extend_map(&mut map, &WESTERN_UNION_ALPHABET),
         };
 
         map

--- a/crates/spellabet/tests/integration/main.rs
+++ b/crates/spellabet/tests/integration/main.rs
@@ -333,6 +333,17 @@ fn test_dump_alphabet_verbose() {
 }
 
 #[test]
+fn test_jan_alphabet() {
+    let alphabet = SpellingAlphabet::Jan;
+    let converter = PhoneticConverter::new(&alphabet);
+
+    assert_snapshot!(
+        converter.convert("abc123xyz"),
+        @"able baker charlie One Two Three x-ray yoke zebra"
+    );
+}
+
+#[test]
 fn test_lapd_alphabet() {
     let alphabet = SpellingAlphabet::Lapd;
     let converter = PhoneticConverter::new(&alphabet);
@@ -364,6 +375,17 @@ fn test_nato_alphabet() {
 }
 
 #[test]
+fn test_royal_navy_alphabet() {
+    let alphabet = SpellingAlphabet::RoyalNavy;
+    let converter = PhoneticConverter::new(&alphabet);
+
+    assert_snapshot!(
+        converter.convert("abc123xyz"),
+        @"apples butter charlie One Two Three xerxes yellow zebra"
+    );
+}
+
+#[test]
 fn test_us_financial_alphabet() {
     let alphabet = SpellingAlphabet::UsFinancial;
     let converter = PhoneticConverter::new(&alphabet);
@@ -371,5 +393,16 @@ fn test_us_financial_alphabet() {
     assert_snapshot!(
         converter.convert("abc123xyz"),
         @"adam bob carol One Two Three xavier yogi zachary"
+    );
+}
+
+#[test]
+fn test_western_union_alphabet() {
+    let alphabet = SpellingAlphabet::WesternUnion;
+    let converter = PhoneticConverter::new(&alphabet);
+
+    assert_snapshot!(
+        converter.convert("abc123xyz"),
+        @"adams boston chicago One Two Three x-ray young zero"
     );
 }

--- a/crates/spellout/src/cli.rs
+++ b/crates/spellout/src/cli.rs
@@ -54,12 +54,18 @@ pub struct Cli {
 
 #[derive(Clone, Debug, ValueEnum)]
 pub enum Alphabet {
+    /// Joint Army/Navy
+    Jan,
     /// Los Angeles Police Department
     Lapd,
     /// North Atlantic Treaty Organization
     Nato,
+    /// Royal Navy
+    RoyalNavy,
     /// United States Financial Industry
     UsFinancial,
+    /// Western Union
+    WesternUnion,
 }
 
 #[derive(Clone, Debug, ValueEnum)]

--- a/crates/spellout/src/main.rs
+++ b/crates/spellout/src/main.rs
@@ -31,9 +31,12 @@ fn main() -> Result<()> {
     }
 
     let alphabet = match cli.alphabet {
+        Alphabet::Jan => SpellingAlphabet::Jan,
         Alphabet::Lapd => SpellingAlphabet::Lapd,
         Alphabet::Nato => SpellingAlphabet::Nato,
+        Alphabet::RoyalNavy => SpellingAlphabet::RoyalNavy,
         Alphabet::UsFinancial => SpellingAlphabet::UsFinancial,
+        Alphabet::WesternUnion => SpellingAlphabet::WesternUnion,
     };
 
     let mut converter = PhoneticConverter::new(&alphabet).nonce_form(cli.nonce_form);


### PR DESCRIPTION
See:
- https://en.wikipedia.org/wiki/Allied_military_phonetic_spelling_alphabets
- https://onlinemilitaryeducation.org/military-alphabet.html
- https://culturegaps.com/nato-western-union-phonetic-alphabets-b4e6b7496fcf

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [x] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [x] Added tests covering any code changes
