### PR TITLE
Pass repository secrets through to bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -27,3 +27,4 @@ jobs:
     with:
       package: ${{ inputs.package }}
       level: ${{ inputs.level }}
+    secrets: inherit


### PR DESCRIPTION
We use a dedicated GitHub App to generate access tokens that will be able to handle the automated triggering of other workflows. Since we're calling a reusable workflow from within the same organization, we can use the `inherits` keyword to implicitly pass all current secrets rather than listing them out explicitly.

See:
- https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
