### PR TITLE
Fake a dependabot increase-if-necessary strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    versioning-strategy: lockfile-only
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
At the moment, the cargo ecosystem does not support the strategy directly, so I'm going to see if dependabot will allow multiple definitions for the same ecosystem in order to work around the problem.

See:
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy
- https://github.com/dependabot/dependabot-core/issues/4009

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
