### PR TITLE
Revert "Fake a dependabot increase-if-necessary strategy"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    versioning-strategy: lockfile-only
-
-  - package-ecosystem: cargo
-    directory: /
-    schedule:
-      interval: weekly
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-patch
-          - version-update:semver-minor
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Turns out dependabot does not allow duplicate ecosystem entries:

> The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'

😞 

Reverts EarthmanMuons/spellout#156