### PR TITLE
Use increase-if-necessary versioning strategy for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    versioning-strategy: increase-if-necessary
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
It looks like maybe the upstream README is out of date for the cargo ecosystem, as the code itself would appear to support the strategy directly and the open issue I found might be able to be closed. Let's try it out and see.

See:
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy
- https://github.com/dependabot/dependabot-core/blob/6a3a59c36b99ea1230fa9b8809c47a7bdd6339ce/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb#L21
- https://github.com/dependabot/dependabot-core/issues/4009

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
