### PR TITLE
Revert "Use increase-if-necessary versioning strategy for cargo"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    versioning-strategy: increase-if-necessary
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Looks like I was wrong with my interpretation of the upstream dependabot-core code and although support for "increase-if-necessary" is included in part of the cargo ecosystem code, not everything that it needs is actually in place. You'll still get an error if you try:

> The property '#/updates/0/versioning-strategy' value "increase-if-necessary" did not match one of the following values: lockfile-only, auto

...and it looks like the dependabot team isn't taking too many community contributions at the moment, so we'll just have to live with the current behavior.

Reverts EarthmanMuons/spellout#159