### PR TITLE
Simplify dependabot group naming

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: weekly
     groups:
-      cargo-dependencies:
+      dependencies:
         patterns:
           - "*"
 


### PR DESCRIPTION
If there's only one ecosystem that we actually want to group, no need to prefix it with the name. This will make the pull request subject lines a bit more clean/clear.

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
