### PR TITLE
Disable clippy ignored_unit_patterns for DeJson derives

### DIFF
--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -1,3 +1,6 @@
+// TODO: Remove once nanoserde release > v0.1.35
+#![allow(clippy::ignored_unit_patterns)]
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::{env, fs};


### PR DESCRIPTION
This is temporary and something that has been addressed upstream by nanoserde, but they haven't yet cut a new release. I've been waiting a while, but will just workaround it for the time being to get CI passing again.

See:
- https://rust-lang.github.io/rust-clippy/master/index.html#/ignored_unit_patterns
- https://github.com/not-fl3/nanoserde/commit/49b61235fd189d16ceb8398fe5eb071a96e9df8f#diff-5b53a23bb18f45cee1492a15b761043be09b2c2e6d764ef3e95a89814de3d556

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
