### PR TITLE
Adjust GitHub Actions workflows based on upstream breaking changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,13 @@
 # See https://github.com/actions/labeler for more information.
 
 dependencies:
-  - Cargo.lock
+  - changed-files:
+      - any-glob-to-any-file: Cargo.lock
 
 documentation:
-  - "**/*.md"
+  - changed-files:
+      - any-glob-to-any-file: "**/*.md"
 
 github_actions:
-  - .github/workflows/*.yml
+  - changed-files:
+      - any-glob-to-any-file: .github/workflows/*.yml

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -22,6 +22,7 @@ jobs:
   deploy_github_pages:
     name: deploy github pages
     permissions:
+      actions: read
       id-token: write
       pages: write
     needs: detect_changed_files


### PR DESCRIPTION
I expect that this may fail on the labeler change since we've already bumped the action version and it gets run from the base branch rather than the HEAD of the Pull Request. That's okay.

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
